### PR TITLE
Bugfix: Disambiguate optimize_or_load positional/keyword args

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -67,12 +67,12 @@ function optimize_or_load(
 
     if isnothing(filename)
         filename = optimization_savename(
-            problem,
+            problem;
             method=method,
             suffix=suffix,
             prefix=prefix,
             savename_kwargs=savename_kwargs,
-            kwargs...,
+            kwargs...
         )
     end
 
@@ -251,8 +251,8 @@ formatted can be customized via `savename_kwargs`.
 See [`default_optimization_savename_kwargs`](@ref) for the supported options.
 """
 function optimization_savename(
-    path,
-    problem;
+    path::AbstractString,
+    problem::ControlProblem;
     method,
     suffix="jld2",
     prefix="",


### PR DESCRIPTION
The way the `@optimize_or_load` macro was calling `optimize_or_load` there was the potential for keyword arguments being passed as positional arguments. Adding a simple semicolon fixes it.