### PR TITLE
 Add: `TestUtils.test()` runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /docs/build/
 /gh-pages/
 /.JuliaFormatter.toml
+/lcov.info
+/coverage

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ servedocs: docs/Manifest.toml  ## Build (auto-rebuild) and serve documentation a
 	$(JULIA) --project=test -e 'include("devrepl.jl"); servedocs(port=$(PORT), verbose=true)'
 
 clean: ## Clean up build/doc/testing artifacts
-	rm -f src/*.cov test/*.cov
+	rm -f src/*.cov test/*.cov lcov.info
+	rm -rf coverage
 	rm -rf docs/build
 
 codestyle: test/Manifest.toml ../.JuliaFormatter.toml ## Apply the codestyle to the entire project

--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,21 @@ authors = ["Michael Goerz <mail@michaelgoerz.net>", "Alastair Marshall <alastair
 version = "0.1.1+dev"
 
 [deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DrWatson = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LocalCoverage = "5f6e1e16-694c-5876-87ef-16b5274f298e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 QuantumPropagators = "7bf12567-5742-4b91-a078-644e72a65fc1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+Coverage = "^1.4"
 Distributions = "^0.25"
 DrWatson = "2"
+LocalCoverage = "^0.2"
 QuantumPropagators = ">=0.1.0"
 julia = "1.6"

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -3,12 +3,123 @@ module TestUtils
 export random_complex_matrix, random_real_matrix, random_hermitian_matrix
 export random_complex_sparse_matrix, random_real_sparse_matrix
 export random_hermitian_sparse_matrix, random_state_vector
+export test
 
-
+using Logging
 using Random
 using Distributions
 using LinearAlgebra
 using SparseArrays
+using Coverage
+using LocalCoverage
+
+
+"""Run a package test-suite in a subprocess.
+
+```julia
+test(
+    file="test/runtests.jl";
+    root=pwd(),
+    project="test",
+    code_coverage="user",
+    show_coverage=(code_coverage == "user"),
+    color="auto",
+    startup_file="yes",
+    depwarn="yes",
+    check_bounds="yes",
+    genhtml=false,
+    covdir="coverage"
+)
+```
+
+runs the test suite of the package located at `root` by running `include(file)`
+inside a new julia process.
+
+This is similar to what `Pkg.test()` does, but differs in the "sandboxing"
+approach. While `Pkg.test()` creates a new temporary sandboxed environment,
+`test()` uses an existing environment in `project` (the `test` subfolder by
+default). This allows testing against the dev-versions of other packages. It
+requires that the `test` folder contains both a `Project.toml` and a
+`Manifest.toml` file.
+
+The `test()` function also differs from directly including `test/runtests.jl`
+in the REPL in that it can generate coverage data and reports (this is only
+possible when running tests in a subprocess).
+
+If `show_coverage` is passed as `true` (default), a coverage summary is shown.
+Further, if `genhtml` is `true`, a full HTML coverage report will be generated
+in `covdir`. This requires the `genhtml` executable (part of the
+[lcov](http://ltp.sourceforge.net/coverage/lcov.php) package). Instead of
+`true`, it is also possible to pass the path to the `genhtml` exectuable.
+
+All other keyword arguments correspond to the respective command line flag for
+the `julia` executable that is run as the subprocess.
+
+This function is intended to be exposed in a project's development-REPL.
+"""
+function test(
+    file="test/runtests.jl";
+    root=pwd(),
+    project="test",
+    code_coverage="user",
+    show_coverage=(code_coverage == "user"),
+    color="auto",
+    startup_file="yes",
+    depwarn="yes",
+    check_bounds="yes",
+    genhtml::Union{Bool,AbstractString}=false,
+    covdir="coverage"
+)
+    julia = Base.julia_cmd().exec[1]
+    cmd = [
+        julia,
+        "--project=$project",
+        "--color=$color",
+        "--startup-file=$startup_file",
+        "--code-coverage=$code_coverage",
+        "--depwarn=$depwarn",
+        "--check-bounds=$check_bounds",
+        "-e",
+        "include(\"$file\")"
+    ]
+    @info "Running '$(join(cmd, " "))' in subprocess"
+    run(Cmd(Cmd(cmd), dir=root))
+    tracefile = joinpath(root, "lcov.info")
+    if show_coverage || genhtml
+        logger = Logging.SimpleLogger(Logging.Error)
+        local coverage
+        Logging.with_logger(logger) do
+            coverage = Coverage.process_folder(joinpath(root, "src"))
+        end
+        if show_coverage
+            coverage_summary(coverage)
+        end
+        (genhtml === true) && (genhtml = "genhtml")
+        (genhtml === false) && (genhtml = "")
+        if !isempty(genhtml)
+            LocalCoverage.CoverageTools.LCOV.writefile(
+                joinpath(covdir, tracefile),
+                coverage
+            )
+            branch = try
+                strip(read(`git rev-parse --abbrev-ref HEAD`, String))
+            catch e
+                @warn "git branch could not be detected.\nError message: $(sprint(Base.showerror, e))"
+            end
+            title = isnothing(branch) ? "N/A" : "on branch $(branch)"
+            try
+                run(`$(genhtml) -t $(title) -o $(covdir) $(tracefile)`)
+            catch e
+                @error(
+                    "Failed to run $(genhtml). Check that lcov is installed.\nError message: $(sprint(Base.showerror, e))"
+                )
+            end
+            @info("Generated coverage HTML. Serve with 'LiveServer.serve(dir=\"$covdir\")'")
+        end
+    end
+end
+
+
 
 
 """Construct a random complex matrix of size N×N with spectral radius ρ.

--- a/test/init.jl
+++ b/test/init.jl
@@ -1,7 +1,9 @@
 # init file for "make devrepl"
 using Revise
 using JuliaFormatter
-using LiveServer: serve, servedocs
+using QuantumControlBase.TestUtils: test
+using LiveServer: LiveServer, serve, servedocs
+
 
 println("""
 *******************************************************************************
@@ -10,6 +12,10 @@ DEVELOPMENT REPL
 Revise, JuliaFormatter, LiveServer are active.
 
 * `include("test/runtests.jl")` – Run the entire test suite
+* `test()` – Run the entire test suite in a subprocess with coverage
+* `test(genhtml=true)` – Generate an HTML coverage report
+* `Pkg.test("Krotov", coverage=true)` –
+  Run upstream Krotov tests for additional coverage
 * `include("docs/make.jl")` – Generate the documentation
 * `format(".")` – Apply code formatting to all files
 * `servedocs([port=8000, verbose=false])` –


### PR DESCRIPTION
This is a test runner similar to `Pkg.test()` with support for running inside an existing environment (the one defined by `test/Project.toml` and `test/Manifest.toml`). Unlike `Pkg.test()`, this allows to to test against dev-versions of other packages.

It also incorporates the features of [LocalCoverage](https://github.com/JuliaCI/LocalCoverage.jl), allowing to print a coverage summary and generate an HTML report.