### PR TITLE
Add support for calculating gradients via Zygote

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,11 +15,13 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QuantumPropagators = "7bf12567-5742-4b91-a078-644e72a65fc1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Coverage = "^1.4"
 Distributions = "^0.25"
 DrWatson = "2"
 LocalCoverage = "^0.2, 0.3"
+Zygote = "0.6"
 QuantumPropagators = ">=0.1.2"
 julia = "1.6"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,6 +19,9 @@ Pages = ["index.md"]
 
 ## Reference
 
+``\gdef\tgt{\text{tgt}}``
+``\gdef\tr{\operatorname{tr}}``
+
 ```@autodocs
 Modules = [QuantumControlBase, QuantumControlBase.Shapes, QuantumControlBase.Functionals, QuantumControlBase.ConditionalThreads, QuantumControlBase.TestUtils]
 ```

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -1,19 +1,53 @@
 module Functionals
 
-export F_ss, J_T_ss, chi_ss!, F_sm, J_T_sm, chi_sm!, F_re, J_T_re, chi_re!
-export grad_J_T_sm!
+export J_T_ss, J_T_sm, J_T_re
+export make_gradient, make_chi
 
 import ..WeightedObjective
 
 
 using LinearAlgebra
+using Zygote
 
 
-"""Average complex overlap of the target states with forward-propagated states.
+@doc raw"""
+Average complex overlap of the target states with forward-propagated states.
 
 ```julia
 f_tau(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+f_τ = \frac{1}{N} \sum_{k=1}^{N} w_k τ_k
+```
+
+with
+
+```math
+τ_k = ⟨ϕ_k^\tgt|ϕ_k(T)⟩
+```
+
+in Hilbert space, or
+
+```math
+τ_k = \tr[ρ̂_k^{\tgt\,\dagger} ρ̂_k(T)]
+```
+
+in Liouville space, where ``|ϕ_k⟩`` or ``ρ̂_k`` are the elements
+of `ϕ`, and ``|ϕ_k^\tgt⟩`` or ``ρ̂_k^\tgt`` are the
+target states from the `target_state` field of the `objectives`. If `τ` is
+given as a keyword argument, it must contain the values `τ_k` according to the
+above definition. Otherwise, the ``τ_k`` values will be calculated internally.
+
+``N`` is the number of objectives, and ``w_k`` is an optional weight for each
+objective. For any objective that has a `weight` attribute (cf.
+[`WeightedObjective`](@ref)), the ``w_k`` is taken from that attribute;
+otherwise, ``w_k = 1``. The weights, if present, are not automatically
+normalized, they are assumed to have values such that the resulting ``f_τ``
+lies in the unit circle of the complex plane. Usually, this means that the
+weights should sum to ``N``.
 """
 function f_tau(ϕ, objectives; τ=nothing)
     N = length(objectives)
@@ -30,11 +64,19 @@ function f_tau(ϕ, objectives; τ=nothing)
 end
 
 
-"""State-to-state phase-insensitive fidelity.
+@doc raw"""State-to-state phase-insensitive fidelity.
 
 ```julia
 F_ss(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+F_{\text{ss}} = \frac{1}{N} \sum_{k=1}^{N} w_k |τ_k|^2 \quad\in [0, 1]
+```
+
+with ``N``, ``w_k`` and ``τ_k`` as in [`f_tau`](@ref).
 """
 function F_ss(ϕ, objectives; τ=nothing)
     N = length(objectives)
@@ -46,22 +88,42 @@ function F_ss(ϕ, objectives; τ=nothing)
     return real(F)
 end
 
-"""State-to-state phase-insensitive functional.
+@doc raw"""State-to-state phase-insensitive functional.
 
 ```julia
 J_T_ss(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+J_{T,\text{ss}} = 1 - F_{\text{ss}} \in [0, 1].
+```
+
+All arguments are passed to [`F_ss`](@ref).
 """
 function J_T_ss(ϕ, objectives; τ=nothing)
     return 1.0 - F_ss(ϕ, objectives; τ=τ)
 end
 
 
-"""Krotov-states χ for functional [`J_T_ss`](@ref).
+@doc raw"""Krotov-states χ for functional [`J_T_ss`](@ref).
 
 ```julia
 chi_ss!(χ, ϕ, objectives; τ=nothing)
 ```
+
+sets the elements of `χ` according to
+
+```math
+|χ_k⟩
+= -\frac{∂ J_{T,\text{ss}}}{∂ ⟨ϕ_k(T)|}
+= \frac{1}{N} w_k τ_k |ϕ^{\tgt}_k⟩
+```
+
+with ``|ϕ^{\tgt}_k⟩``, ``τ_k`` and ``w_k`` as defined in [`f_tau`](@ref).
+
+Note: this function can be obtained with `make_chi(J_T_ss, objectives)`.
 """
 function chi_ss!(χ, ϕ, objectives; τ=nothing)
     N = length(objectives)
@@ -78,48 +140,99 @@ function chi_ss!(χ, ϕ, objectives; τ=nothing)
 end
 
 
-"""Square-modulus fidelity.
+@doc raw"""Square-modulus fidelity.
 
 ```julia
 F_sm(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+F_{\text{sm}} = |f_τ|^2  \quad\in [0, 1].
+```
+
+All arguments are passed to [`f_tau`](@ref) to evaluate ``f_τ``.
 """
 function F_sm(ϕ, objectives; τ=nothing)
     return abs(f_tau(ϕ, objectives; τ=τ))^2
 end
 
 
-"""Square-modulus functional.
+@doc raw"""Square-modulus functional.
 
 ```julia
 J_T_sm(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+J_{T,\text{sm}} = 1 - F_{\text{sm}} \quad\in [0, 1].
+```
+
+All arguments are passed to [`f_tau`](@ref) while evaluating ``F_{\text{sm}}``
+in [`F_sm`](@ref).
 """
 function J_T_sm(ϕ, objectives; τ=nothing)
     return 1.0 - F_sm(ϕ, objectives; τ=τ)
 end
 
 
-"""Gradient for [`J_T_sm`](@ref)."""
-function grad_J_T_sm!(G, τ, ∇τ)
+@doc raw"""Gradient for [`J_T_sm`](@ref).
+
+```julia
+grad_J_T_sm!(∇J_T, τ, ∇τ)
+```
+
+analytically sets the elements of the gradient `∇J_T` according to
+
+```math
+\frac{∂ J_{T,\text{sm}}(\{τ_k\})}{\partial ϵ_{ln}}
+= \frac{1}{N^2} \sum_{k=1}^N \sum_{k'=1}^N\left[
+        \frac{\partial τ_{k'}^*}{∂ϵ_{ln}} τ_k +
+        τ_{k'}^* \frac{\partial τ_k^*}{∂ϵ_{ln}}
+   \right]
+= -\frac{2}{N} \Re \sum_{k=1}^N \sum_{k'=1}^N
+  τ_{k'}^* \frac{∂τ_k}{\partial ϵ_{ln}}
+```
+
+with all quantities as defined in [`make_gradient`](@ref).
+
+Note: this function can be obtained with
+`make_gradient(J_T_sm, objectives, via=:tau)`.
+"""
+function grad_J_T_sm!(∇J_T, τ, ∇τ)
     N = length(τ) # number of objectives
     L, N_T = size(∇τ[1])  # number of controls/time intervals
-    G′ = reshape(G, L, N_T)  # writing to G′ modifies G
+    ∇J_T′ = reshape(∇J_T, L, N_T)  # writing to ∇J_T′ modifies ∇J_T
     for l = 1:L
         for n = 1:N_T
-            G′[l, n] = real(sum([conj(τ[k′]) * ∇τ[k][l, n] for k′ = 1:N for k = 1:N]))
+            ∇J_T′[l, n] = real(sum([conj(τ[k′]) * ∇τ[k][l, n] for k′ = 1:N for k = 1:N]))
         end
     end
-    lmul!(-2 / N^2, G)
-    return G
+    lmul!(-2 / N^2, ∇J_T)
+    return ∇J_T
 end
 
 
-"""Krotov-states χ for functional [`J_T_sm`](@ref).
+@doc raw"""Krotov-states χ for functional [`J_T_sm`](@ref).
 
 ```julia
 chi_sm!(χ, ϕ, objectives; τ=nothing)
 ```
+
+sets the elements of `χ` according to
+
+```math
+|χ_k⟩
+= -\frac{\partial J_{T,\text{sm}}}{\partial ⟨ϕ_k(T)|}
+= \frac{1}{N^2} w_k \sum_{j}^{N} w_j τ_j |ϕ_k^{\tgt}⟩
+```
+
+with ``|ϕ^{\tgt}_k⟩``, ``τ_j`` and ``w_k`` as defined in [`f_tau`](@ref).
+
+Note: this function can be obtained with `make_chi(J_T_sm, objectives)`.
 """
 function chi_sm!(χ, ϕ, objectives; τ=nothing)
 
@@ -144,33 +257,69 @@ function chi_sm!(χ, ϕ, objectives; τ=nothing)
 end
 
 
-"""Real-part fidelity.
+@doc raw"""Real-part fidelity.
 
 ```julia
 F_re(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+F_{\text{re}} = \Re[f_{τ}] \quad\in \begin{cases}
+    [-1, 1] & \text{in Hilbert space} \\
+    [0, 1] & \text{in Liouville space.}
+\end{cases}
+```
+
+All arguments are passed to [`f_tau`](@ref) to evaluate ``f_τ``.
 """
 function F_re(ϕ, objectives; τ=nothing)
     return real(f_tau(ϕ, objectives; τ=τ))
 end
 
 
-"""Real-part functional.
+@doc raw"""Real-part functional.
 
 ```julia
 J_T_re(ϕ, objectives; τ=nothing)
 ```
+
+calculates
+
+```math
+J_{T,\text{re}} = 1 - F_{\text{re}} \quad\in \begin{cases}
+    [0, 2] & \text{in Hilbert space} \\
+    [0, 1] & \text{in Liouville space.}
+\end{cases}
+```
+
+All arguments are passed to [`f_tau`](@ref) while evaluating ``F_{\text{re}}``
+in [`F_re`](@ref).
 """
 function J_T_re(ϕ, objectives; τ=nothing)
     return 1.0 - F_re(ϕ, objectives; τ=τ)
 end
 
 
-"""Krotov-states χ for functional [`J_T_re`](@ref).
+@doc raw"""Krotov-states χ for functional [`J_T_re`](@ref).
 
 ```julia
 chi_re!(χ, ϕ, objectives; τ=nothing)
 ```
+
+sets the elements of `χ` according to
+
+
+```math
+|χ_k⟩
+= -\frac{∂ J_{T,\text{re}}}{∂ ⟨ϕ_k(T)|}
+= \frac{1}{2N} w_k |ϕ^{\tgt}_k⟩
+```
+
+with ``|ϕ^{\tgt}_k⟩`` and ``w_k`` as defined in [`f_tau`](@ref).
+
+Note: this function can be obtained with `make_chi(J_T_re, objectives)`.
 """
 function chi_re!(χ, ϕ, objectives; τ=nothing)
     N = length(objectives)
@@ -185,5 +334,299 @@ function chi_re!(χ, ϕ, objectives; τ=nothing)
         lmul!(w / (2N), χ[k])
     end
 end
+
+
+@doc raw"""Gradient for an arbitrary functional evaluated via χ-states.
+
+```julia
+grad_J_T_via_chi!(∇J_T, τ, ∇τ)
+```
+
+sets the (vectorized) elements of the gradient `∇J_T` to the gradient
+``∂J_T/∂ϵ_{ln}`` for an arbitrary functional ``J_T=J_T(\{|ϕ_k(T)⟩\})``, under
+the assumption that
+
+```math
+\begin{aligned}
+    τ_k &= ⟨χ_k|ϕ_k(T)⟩ \quad \text{with} \quad |χ_k⟩ &= -∂J_T/∂⟨ϕ_k(T)|
+    \quad \text{and} \\
+    ∇τ_{kln} &= ∂τ_k/∂ϵ_{ln}\,,
+\end{aligned}
+```
+
+where ``|ϕ_k(T)⟩`` is a state resulting from the forward propagation of some
+initial state ``|ϕ_k⟩`` under the pulse values ``ϵ_{ln}`` where ``l`` numbers
+the controls and ``n`` numbers the time slices. The ``τ_k`` are the elements of
+`τ` and ``∇τ_{kln}`` corresponds to `∇τ[k][l, n]`.
+
+In this case,
+
+```math
+(∇J_T)_{ln} = ∂J_T/∂ϵ_{ln} = -2 \Re \sum_k ∇τ_{kln}\,,
+```
+
+see [`make_gradient`](@ref).
+
+Note that the definition of the ``|χ_k⟩`` matches exactly the definition
+of the boundary condition for the backward propagation in Krotov's method, see
+[`make_chi`](@ref). Specifically, there is a minus sign in front of the
+derivative, compensated by the minus sign in the factor ``(-2)`` of the final
+``(∇J_T)_{ln}``.
+"""
+function grad_J_T_via_chi!(∇J_T, τ, ∇τ)
+    N = length(τ) # number of objectives
+    L, N_T = size(∇τ[1])  # number of controls/time intervals
+    ∇J_T′ = reshape(∇J_T, L, N_T)  # writing to ∇J_T′ modifies ∇J_T
+    for l = 1:L
+        for n = 1:N_T
+            ∇J_T′[l, n] = real(sum([∇τ[k][l, n] for k = 1:N]))
+        end
+    end
+    lmul!(-2, ∇J_T)
+    return ∇J_T
+end
+
+
+@doc raw"""Return a function that evaluates the gradient ``∇J_T``.
+
+```julia
+grad_func! = make_gradient(J_T, objectives; via=:tau, force_zygote=false)
+```
+
+creates a function `gradfunc!(∇J_T, τ, ∇τ)` that takes a vector `τ` of values
+``τ_k`` and a vector `∇τ` of gradients ``∇τ_k`` where the ``(ln)``'th element
+of ``∇τ_k`` is ``∂τ_k/∂ϵ_{ln}``, and writes the element ``(ln)`` of the
+gradient `∇J_T` as ``∂J_T/∂ϵ_{ln}``. The definition of ``τ_k`` depends on
+`via`, see below. The ``ϵ_{ln}`` are the values of the control control field
+discretized to the midpoints of a time grid. The index ``l`` numbers the
+control and ``n`` numbers the time slice. The gradient (like the controls) are
+assumed to be vectorized. That is, ``∇J_T`` is a vector of values with a
+double-index ``(ln)``.
+
+The passed `J_T` parameter corresponding to the functional ``J_T`` must be a
+function that takes a vector of forward-propagates states `ϕ` and a vector of
+objectives as positional parameters.  It must also accept a vector `τ` as a
+keyword argument, which contains the overlaps of the states in `ϕ` and the
+`target_state` fields of the `objectives`. If the `objectices` do not define
+`target_states`, or if the ``τ``-values are not available, `J_T` must accept
+`τ=nothing`. See [`J_T_sm`](@ref) for an example.
+
+
+## Gradient via τ
+
+For `via=:tau` (default), we define
+
+```math
+τ_k ≡ ⟨ϕ_k^\tgt|ϕ_k(T)⟩
+```
+
+as the overlap of ``|ϕ_k(T)⟩`` resulting from the forward propagation of the
+`initial_state` ``|ϕ_k⟩``  of the k'th objective under the pulse values
+``ϵ_{ln}``, and ``|ϕ_k^\tgt⟩`` as the `target_state` of the k'th objective.
+
+We then understand ``J_T`` as a function of the ``τ_k``, and evaluate the
+elements of ``∇J_T`` via the chain rule:
+
+```math
+(∇J_T)_{ln} ≡ \frac{∂J_T(\{τ_k\})}{∂ϵ_{ln}}
+= 2\Re\sum_k
+    \frac{∂J_T}{∂τ_k}
+    \frac{∂τ_k}{∂ϵ_{ln}}\,.
+```
+
+Since the ``τ_k`` are complex numbers,
+
+```math
+\frac{∂J_T}{∂τ_k} = \frac{1}{2}\left(
+    \frac{∂ J_T}{∂ \Re[τ_k]}
+    - i \frac{∂ J_T}{∂ \Im[τ_k]}
+\right)
+```
+
+is defined as the [Wirtinger
+derivative](https://www.ekinakyurek.me/complex-derivatives-wirtinger/), and
+
+```math
+\frac{∂τ_k}{∂ϵ_{ln}} = \frac{∂\Re[τ_k]}{∂ϵ_{ln}} + i \frac{∂\Im[τ_k]}{∂ϵ_{ln}}
+```
+
+is simply the derivative of a complex number with respect to the real-valued
+``ϵ_{ln}``.
+
+Thus, the returned `grad_func!` effectively encodes the outer derivative
+``∂J_T/∂τ_k``. For functionals where that derivative is known analytically,
+the analytic expression is used, e.g., [`J_T_sm`](@ref) →
+[`grad_J_T_sm!`](@ref).
+
+Otherwise, or if `force_zygote=true`, the outer derivative is
+determined directly from `J_T`, via automatic differentiation (using
+[Zygote](https://fluxml.ai/Zygote.jl)).
+
+## Gradient via χ
+
+For `via=:chi`, the functional ``J_T`` is understood directly as a function of
+the forward-propagated states ``|ϕ_k⟩`` instead of a function of overlaps with
+the target states. This is useful in particular if the `objectives` do not
+define objectives and/or the functional `J_T` cannot be expressed in terms of
+overlaps.
+
+Again we apply a chain rule to calculate the elements of the gradient ``∇J_T``:
+
+```math
+\begin{split}
+(∇J_T)_{ln} &≡ \frac{∂J_T(\{|ϕ_k(T)⟩\})}{∂ϵ_{ln}}\\
+&= 2\Re\sum_k
+    \frac{∂J_T}{∂|ϕ_k(T)⟩}
+    \frac{∂|ϕ_k(T)⟩}{∂ϵ_{ln}} \\
+&= -2 \Re \sum_k \frac{∂}{∂ϵ_{ln}} ⟨χ_k(T)|ϕ_k(T)⟩\,,
+\end{split}
+```
+
+with
+
+```math
+|χ_k⟩
+= -\frac{J_T}{⟨ϕ_k(T)|}
+= -\frac{1}{2}\left(
+    \left\vert \frac{∂J_T}{∂\Re[ϕ_k]} \right\rangle
+    + i \left\vert \frac{∂J_T}{∂\Im[ϕ_k]} \right\rangle
+    \right)
+```
+
+as a matrix-calculus extension of the Wirtinger derivative. This definition of
+``|χ_k⟩`` (note the minus sign!) matches the definition of the boundary
+condition in Krotov's method, and for a given functional `J_T`, the
+states ``|χ_k⟩`` can be obtained with [`make_chi`](@ref).
+
+We define
+
+```math
+τ_k ≡ ⟨χ_k(T)|ϕ_k(T)⟩
+```
+
+and associate the `gradfunc!` argument `∇τ[k][l, n]` with
+
+```math
+(∇τ_k)_{ln} = \frac{∂τ_k}{∂ ϵ_{ln}}
+```
+
+so that structurally, ``(∇J_T)_{ln}`` is the same as for `via=:tau`, just that
+``τ_k`` is now defined with respect to the boundary condition state ``|χ_k⟩``
+instead of the target state ``|ϕ_k^\tgt⟩``.
+
+The returned `grad_func!` that encodes the above equations is
+[`grad_J_T_via_chi!`](@ref). This is independent of `J_T`, since the dependency
+on the functional `J_T` is entirely encoded in the states ``|χ_k(T)⟩``, and
+thus the gradient `∇τ`. Also, `force_zygote=true` has no effect for `via=:chi`.
+Instead, `force_zygote` should be passed to the underlying [`make_chi`](@ref).
+
+!!! tip
+
+    In order to extend `make_gradient` with an analytic implementation for a
+    new `J_T` function, define a new method like so:
+
+    ```julia
+    make_gradient(::typeof(J_T_sm), objectives, via::Val{:tau}) = grad_J_T_sm!
+    ```
+
+    which links `make_gradient` for [`J_T_sm`](@ref) to [`grad_J_T_sm!`](@ref).
+"""
+function make_gradient(J_T, objectives; via::Symbol=:tau, force_zygote=false)
+    if force_zygote && (via == :tau)
+        return make_zygote_gradient(J_T, objectives)
+    else
+        return make_gradient(J_T, objectives, Val(via))
+    end
+end
+
+function make_zygote_gradient(J_T, objectives)
+
+    function zygote_gradfunc!(∇J_T, τ, ∇τ)
+        ∇J = Zygote.gradient(τ -> J_T(nothing, objectives; τ=τ), τ)[1]
+        ∇J_T .= vec(sum(real(∇J) .* real.(∇τ) + imag(∇J) .* imag.(∇τ)))
+    end
+
+    return zygote_gradfunc!
+end
+
+make_gradient(J_T, objectives, via::Val{:chi}) = grad_J_T_via_chi!
+make_gradient(J_T, objectives, via::Val{:tau}) = make_zygote_gradient(J_T, objectives)
+make_gradient(::typeof(J_T_sm), objectives, via::Val{:tau}) = grad_J_T_sm!
+
+
+@doc raw"""Return a function that evaluates ``|χ_k⟩ = -∂J_T/∂⟨ϕ_k|``.
+
+```julia
+chi! = make_chi(J_T, objectives; force_zygote=false)
+```
+
+creates a function `chi!(χ, ϕ, objectives; τ=nothing)` that sets
+``|χ_k⟩ = -∂J_T/∂⟨ϕ_k|``. This is the state used as the boundary condition for
+the backward propagation propagation in Krotov's method, as well as GRAPE if
+[`grad_J_T_via_chi!`](@ref) is used. It is defined as a [Wirtinger
+derivative](https://www.ekinakyurek.me/complex-derivatives-wirtinger/),
+see [`make_gradient`](@ref).
+
+The function `J_T` must take a vector of states `ϕ`
+and a vector of `objectives` as positional parameters, and a vector `τ` as a
+keyword argument, see e.g. [`J_T_sm`](@ref). If all objectives define a
+`target_state`, then `τ` will be the overlap of the states `ϕ` with those
+target states. The functional `J_T` may or may not use those overlaps.
+Likewise, the resulting `chi!` may or may not use the keyword parameter `τ`.
+
+For functionals where ``-∂J_T/∂⟨ϕ_k|`` is known analytically, that analytic
+derivative will be returned, e.g.,
+
+* [`J_T_sm`](@ref) → [`chi_sm!`](@ref),
+* [`J_T_re`](@ref) → [`chi_re!`](@ref),
+* [`J_T_ss`](@ref) → [`chi_ss!`](@ref).
+
+Otherwise, or if `force_zygote=true`, automatic differentiation via Zygote is
+used to calculate the derivative directly from `J_T`.
+
+!!! tip
+
+    In order to extend `make_chi` with an analytic implementation for a new
+    `J_T` function, define a new method `make_analytic_chi` like so:
+
+    ```julia
+    make_analytic_chi(::typeof(J_T_sm), objectives) = chi_sm!
+    ```
+
+    which links `make_chi` for [`J_T_sm`](@ref) to [`chi_sm!`](@ref).
+"""
+function make_chi(J_T, objectives; force_zygote=false)
+    if force_zygote
+        return make_zygote_chi(J_T, objectives)
+    else
+        return make_analytic_chi(J_T, objectives)
+    end
+end
+
+function make_zygote_chi(J_T, objectives)
+
+    N = length(objectives)
+
+    function zygote_chi!(χ, ϕ, objectives; τ=nothing)
+        function _J_T(Ψ...)
+            -J_T(Ψ, objectives)
+        end
+        for (k, ∇J) ∈ enumerate(Zygote.gradient(_J_T, ϕ...))
+            copyto!(χ[k], ∇J)
+            lmul!(0.5, χ[k])
+        end
+    end
+
+    return zygote_chi!
+
+end
+
+make_analytic_chi(J_T, objectives) = make_zygote_chi(J_T, objectives)
+# Well, the above fallback to `make_zygote_chi` is clearly not "analytic", but
+# the intent of this name is to allow users to define new analytic
+# implementation, cf. the explanation in the doc of `make_chi`.
+make_analytic_chi(::typeof(J_T_sm), objectives) = chi_sm!
+make_analytic_chi(::typeof(J_T_re), objectives) = chi_re!
+make_analytic_chi(::typeof(J_T_ss), objectives) = chi_ss!
 
 end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -81,7 +81,7 @@ function optimize_or_load(
     file = joinpath(path, filename)
     if dry_run
         if verbose
-            if isfile(file)
+            if isfile(file) && !force
                 @info "Would load result from $file"
             else
                 @info "Would optimize and store in $file"
@@ -90,7 +90,11 @@ function optimize_or_load(
         return nothing, file
     end
     if isfile(file) && verbose
-        @info "Loading result from $file"
+        if force
+            @info "Ignoring existing $file (force)"
+        else
+            @info "Loading result from $file"
+        end
     end
 
     data, file = DrWatson.produce_or_load(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,11 @@ using SafeTestsets
         include("test_gradgen.jl")
     end
 
+    print("\n* Functionals (test_functionals.jl):")
+    @time @safetestset "Functionals" begin
+        include("test_functionals.jl")
+    end
+
     print("\n* Infohook (test_infohook.jl):")
     @time @safetestset "Infohook" begin
         include("test_infohook.jl")

--- a/test/test_functionals.jl
+++ b/test/test_functionals.jl
@@ -1,0 +1,210 @@
+using Test
+using LinearAlgebra
+using QuantumControlBase.Functionals
+using QuantumControlBase.Functionals:
+    chi_re!, chi_sm!, chi_ss!, make_zygote_gradient, make_zygote_chi, grad_J_T_sm!
+using QuantumControlBase.TestUtils
+
+
+N_HILBERT = 10
+N = 4
+L = 2
+N_T = 50
+PROBLEM = dummy_control_problem(; N=N_HILBERT, n_objectives=N, n_controls=L, n_steps=N_T)
+
+
+@testset "zygote-gradients" begin
+
+    # Test that Zygote gradients and analytical gradients give the same result
+
+    objectives = PROBLEM.objectives
+    G1 = zeros(L * N_T)
+    G2 = zeros(L * N_T)
+    τ = rand(N) .* exp.((1im * 2π) .* rand(N))
+    ∇τ = [rand(L, N_T) .* exp.((1im * 2π) .* rand(L, N_T)) for k = 1:N]
+    grad_J_T_sm_zyg! = make_gradient(J_T_sm, objectives; via=:tau, force_zygote=true)
+    grad_J_T_sm!(G1, τ, ∇τ)
+    grad_J_T_sm_zyg!(G2, τ, ∇τ)
+    @test norm(G1 - G2) < 1e-15
+
+end
+
+
+@testset "chi-with-tau" begin
+
+    # Test that the various chi routines give the same result whether they are
+    # called with ϕ states or with τ values
+
+    objectives = PROBLEM.objectives
+    χ1 = [similar(obj.initial_state) for obj in objectives]
+    χ2 = [similar(obj.initial_state) for obj in objectives]
+    ϕ = [random_state_vector(N_HILBERT) for k = 1:N]
+    τ = [obj.target_state ⋅ ϕ[k] for (k, obj) in enumerate(objectives)]
+
+    chi_re!(χ1, ϕ, objectives)
+    chi_re!(χ2, ϕ, objectives; τ=τ)
+    @test maximum(norm.(χ1 .- χ2)) < 1e-15
+
+    chi_sm!(χ1, ϕ, objectives)
+    chi_sm!(χ2, ϕ, objectives; τ=τ)
+    @test maximum(norm.(χ1 .- χ2)) < 1e-15
+
+    chi_ss!(χ1, ϕ, objectives)
+    chi_ss!(χ2, ϕ, objectives; τ=τ)
+    @test maximum(norm.(χ1 .- χ2)) < 1e-15
+
+end
+
+
+@testset "zygote-chi" begin
+
+    # Test that the zygote chi routines give the same results as the analytical
+    # chi routines
+
+    objectives = PROBLEM.objectives
+    χ1 = [similar(obj.initial_state) for obj in objectives]
+    χ2 = [similar(obj.initial_state) for obj in objectives]
+    ϕ = [random_state_vector(N_HILBERT) for k = 1:N]
+    τ = [obj.target_state ⋅ ϕ[k] for (k, obj) in enumerate(objectives)]
+
+    chi_re!(χ1, ϕ, objectives)
+    chi_re_zyg! = make_chi(J_T_re, objectives; force_zygote=true)
+    chi_re_zyg!(χ2, ϕ, objectives; τ=τ)
+    @test maximum(norm.(χ1 .- χ2)) < 1e-15
+
+    chi_sm!(χ1, ϕ, objectives)
+    chi_sm_zyg! = make_zygote_chi(J_T_sm, objectives)
+    chi_sm_zyg!(χ2, ϕ, objectives; τ=τ)
+    @test maximum(norm.(χ1 .- χ2)) < 1e-15
+
+    chi_ss!(χ1, ϕ, objectives)
+    chi_ss_zyg! = make_zygote_chi(J_T_ss, objectives)
+    chi_ss_zyg!(χ2, ϕ, objectives; τ=τ)
+    @test maximum(norm.(χ1 .- χ2)) < 1e-15
+
+end
+
+
+@testset "make-gradient" begin
+
+    # Test that the routine returned by `make_gradient` gives the same result
+    # as the Zygote gradient
+
+    objectives = PROBLEM.objectives
+    G1 = zeros(L * N_T)
+    G2 = zeros(L * N_T)
+    τ = rand(N) .* exp.((1im * 2π) .* rand(N))
+    ∇τ = [rand(L, N_T) .* exp.((1im * 2π) .* rand(L, N_T)) for k = 1:N]
+
+    for functional in (J_T_sm, J_T_re, J_T_ss)
+        grad_auto! = make_gradient(functional, objectives; via=:tau)
+        grad_zyg! = make_zygote_gradient(functional, objectives)
+        grad_auto!(G1, τ, ∇τ)
+        grad_zyg!(G2, τ, ∇τ)
+        @test norm(G1 - G2) < 1e-15
+    end
+
+end
+
+
+@testset "make-chi" begin
+
+    # Test that the routine returned by `make_chi` gives the same result
+    # as the Zygote chi
+
+    objectives = PROBLEM.objectives
+    χ1 = [similar(obj.initial_state) for obj in objectives]
+    χ2 = [similar(obj.initial_state) for obj in objectives]
+    ϕ = [random_state_vector(N_HILBERT) for k = 1:N]
+    τ = [obj.target_state ⋅ ϕ[k] for (k, obj) in enumerate(objectives)]
+
+    for functional in (J_T_sm, J_T_re, J_T_ss)
+        chi_auto! = make_chi(functional, objectives)
+        chi_zyg! = make_zygote_chi(functional, objectives)
+        chi_auto!(χ1, ϕ, objectives; τ=τ)
+        chi_zyg!(χ2, ϕ, objectives)
+        @test maximum(norm.(χ1 .- χ2)) < 1e-15
+    end
+
+end
+
+
+@testset "gradient-via-chi" begin
+
+    # Test that gradients calculated via chi give the same results as gradients
+    # calculated via tau
+
+    problem = dummy_control_problem(; N=N_HILBERT, n_objectives=2, n_controls=1, n_steps=2)
+    objectives = problem.objectives
+    dt = problem.tlist[2] - problem.tlist[1]
+    Ĥ₀ = Array(objectives[1].generator[1])
+    Ĥ₁ = Array(objectives[1].generator[2][1])
+    𝟘 = zeros(ComplexF64, N_HILBERT, N_HILBERT)
+    ϵ = objectives[1].generator[2][2]
+    Ψtgt = [obj.target_state for obj in objectives]
+    χ = [similar(Ψ) for Ψ in Ψtgt]
+    χ_from_τ = [similar(Ψ) for Ψ in Ψtgt]
+    ∇τ_tgt = [zeros(ComplexF64, 1, 2) for k = 1:2]
+    ∇τ_chi = [zeros(ComplexF64, 1, 2) for k = 1:2]
+    G1 = zeros(2)
+    G2 = zeros(2)
+
+    # forward propagation of states
+    Ψ0 = [obj.initial_state for obj in objectives]
+    Ĥ1 = Ĥ₀ + ϵ[1] * Ĥ₁
+    Ĥ2 = Ĥ₀ + ϵ[2] * Ĥ₁
+    Ψ1 = [exp(-1im * Ĥ1 * dt) * Ψ for Ψ in Ψ0]
+    Ψ2 = [exp(-1im * Ĥ2 * dt) * Ψ for Ψ in Ψ1]
+
+    # overlap with target state
+    τ_tgt = [Ψtgt[k] ⋅ Ψ2[k] for k = 1:2]
+
+    # generators for gradient backward propagation
+    G1⁺ = [Ĥ1'  Ĥ₁'; 𝟘  Ĥ1']
+    G2⁺ = [Ĥ2'  Ĥ₁'; 𝟘  Ĥ2']
+
+    # backward propagation of target states / gradients
+    ξ̃2 = [[zeros(ComplexF64, N_HILBERT); Ψtgt[k]] for k = 1:2]
+    ξ̃1 = [exp(1im * G2⁺ * dt) * ξ̃ for ξ̃ in ξ̃2]
+    for k = 1:2
+        ∇τ_tgt[k][1, 2] = ξ̃1[k][1:N_HILBERT] ⋅ Ψ1[k]
+        ξ̃1[k][1:N_HILBERT] .= 0
+    end
+    ξ̃0 = [exp(1im * G1⁺ * dt) * ξ̃ for ξ̃ in ξ̃1]
+    for k = 1:2
+        ∇τ_tgt[k][1, 1] = ξ̃0[k][1:N_HILBERT] ⋅ Ψ0[k]
+        ξ̃0[k][1:N_HILBERT] .= 0
+    end
+
+    for functional in (J_T_sm, J_T_re, J_T_ss)
+
+        # boundary condition for χ-backward prop
+        chi! = make_chi(functional, objectives)
+        chi!(χ, Ψ2, objectives)
+        chi!(χ_from_τ, Ψ2, objectives; τ=τ_tgt)
+        @test maximum(norm.(χ .- χ_from_τ)) < 1e-15
+        τ_chi = [χ[k] ⋅ Ψ2[k] for k = 1:2]
+
+        # backward propagation of chi states / gradients
+        χ̃2 = [[zeros(ComplexF64, N_HILBERT); χ[k]] for k = 1:2]
+        χ̃1 = [exp(1im * G2⁺ * dt) * χ̃ for χ̃ in χ̃2]
+        for k = 1:2
+            ∇τ_chi[k][1, 2] = χ̃1[k][1:N_HILBERT] ⋅ Ψ1[k]
+            χ̃1[k][1:N_HILBERT] .= 0
+        end
+        χ̃0 = [exp(1im * G1⁺ * dt) * χ̃ for χ̃ in χ̃1]
+        for k = 1:2
+            ∇τ_chi[k][1, 1] = χ̃0[k][1:N_HILBERT] ⋅ Ψ0[k]
+            χ̃0[k][1:N_HILBERT] .= 0
+        end
+
+        grad_J_T_via_tau! = make_gradient(functional, objectives; via=:tau)
+        grad_J_T_via_chi! = make_gradient(functional, objectives; via=:chi)
+        @test grad_J_T_via_tau! ≢ grad_J_T_via_chi!
+        grad_J_T_via_tau!(G1, τ_tgt, ∇τ_tgt)
+        grad_J_T_via_chi!(G2, τ_chi, ∇τ_chi)
+        @test norm(G1 - G2) < 1e-15
+
+    end
+
+end

--- a/test/test_gradgen.jl
+++ b/test/test_gradgen.jl
@@ -115,14 +115,14 @@ using Zygote
     @test norm(Ψ̃_out_full[N+1:2N] - Ψ̃_out.grad_states[2]) < 1e-12
 
     ###########################################################################
-    # Test custom expprop
+    # Test standard expprop
 
     wrk_exp = initpropwrk(Ψ̃, [0, dt], Val(:expprop), G̃)
     propstep!(Ψ̃, G̃, dt, wrk_exp)
     Ψ̃_out_exp = copy(Ψ̃)
     @test norm(wrk_exp.Ψ_full - Ψ̃_full) ≈ 0.0
     @test norm(wrk_exp.G_full - G̃_full) ≈ 0.0
-    @test norm(Ψ̃_out_exp - Ψ̃_out) < 1e-12
+    @test norm(Ψ̃_out_exp - Ψ̃_out) < 1e-11
     resetgradvec!(Ψ̃, Ψ)
 
 


### PR DESCRIPTION
This functionally replaces all `grad_*` and `chi_*` routines with a `make_gradient` and `make_chi` function that automatically selects the correct implementation based on on a given `J_T_*` function. For known functionals with analytic gradients, it uses the hand-written implementation. For all others, it generates a routine that calculates the gradient via automatic differentiation, using Zygote.
