### PR TITLE
Add `MinimalObjective`

### DIFF
--- a/src/QuantumControlBase.jl
+++ b/src/QuantumControlBase.jl
@@ -1,7 +1,7 @@
 module QuantumControlBase
 
 include("controlproblem.jl")
-export ControlProblem, Objective, WeightedObjective
+export ControlProblem, Objective, MinimalObjective, WeightedObjective
 
 include("propagate.jl")
 export propagate_objective

--- a/src/controlproblem.jl
+++ b/src/controlproblem.jl
@@ -39,6 +39,30 @@ struct Objective{ST,GT} <: AbstractControlObjective
 end
 
 
+"""Minmal optimization objective (initial state and dynamical generator only).
+
+```julia
+Objective(;
+    initial_state=<initial_state>,
+    generator=<generator>,
+)
+```
+
+describes and optimization objective like the standard [`Objective`](@ref),
+except for functionals that are not expressed with respect to some
+`target_state`. Having only an `initial_state` and a `generator`, this is the
+minimal data structure that is a valid instance of
+[`AbstractControlObjective`](@ref).
+"""
+struct MinimalObjective{ST,GT} <: AbstractControlObjective
+    initial_state::ST
+    generator::GT
+    function MinimalObjective(; initial_state::ST, generator::GT) where {ST,GT}
+        new{ST,GT}(initial_state, generator)
+    end
+end
+
+
 """Standard optimization objective with a weight.
 
 ```julia


### PR DESCRIPTION
This is an objective that only includes an initial state and a dynamic generator, suitable e.g. for a perfect entangler optimization