### PR TITLE
Remove automatic file names in `@optimize_or_load`

### DIFF
--- a/src/QuantumControlBase.jl
+++ b/src/QuantumControlBase.jl
@@ -25,8 +25,7 @@ include("saving.jl")               # submodule Saving
 
 
 include("optimize.jl")
-export optimize, @optimize_or_load, optimization_savename, load_optimization
-export default_optimization_savename_kwargs
+export optimize, @optimize_or_load, load_optimization
 
 using .TestUtils: optimize_with_dummy_method
 optimize(problem, method::Val{:dummymethod}) = optimize_with_dummy_method(problem)

--- a/test/test_optimize_or_load.jl
+++ b/test/test_optimize_or_load.jl
@@ -3,41 +3,21 @@ using Test
 using QuantumControlBase
 using QuantumControlBase.TestUtils
 
-@testset "dry-run" begin
-
-    problem = dummy_control_problem()
-    file_expected = joinpath(tempdir(), "dry-run.jld2")
-    result, file =
-        @test_logs (:info, "Would optimize and store in $file_expected") @optimize_or_load(
-            tempdir(),
-            problem;
-            method=:dummymethod,
-            filename="dry-run.jld2",
-            dry_run=true,
-            verbose=true
-        )
-    @test isnothing(result)
-    @test file == file_expected
-
-end
-
-
 @testset "metadata" begin
 
     problem = dummy_control_problem()
     outdir = mktempdir()
+    outfile = joinpath(outdir, "optimization_with_metadata.jld2")
     println("")
-    result, file = @optimize_or_load(
-        outdir,
+    result = @optimize_or_load(
+        outfile,
         problem;
         method=:dummymethod,
-        filename="optimization_with_metadata.jld2",
         metadata=Dict("testset" => "metadata", "method" => :dummymethod,)
     )
     @test result.converged
-    @test basename(file) == "optimization_with_metadata.jld2"
-    @test isfile(file)
-    result_load, metadata = load_optimization(file; return_metadata=true)
+    @test isfile(outfile)
+    result_load, metadata = load_optimization(outfile; return_metadata=true)
     @test result_load isa QuantumControlBase.TestUtils.DummyOptimizationResult
     @test result_load.message == "Reached maximum number of iterations"
     @test metadata["testset"] == "metadata"
@@ -49,16 +29,11 @@ end
 @testset "continue_from" begin
     problem = dummy_control_problem()
     outdir = mktempdir()
+    outfile = joinpath(outdir, "optimization_stage1.jld2")
     println("")
-    result, file = @optimize_or_load(
-        outdir,
-        problem;
-        iter_stop=5,
-        method=:dummymethod,
-        filename="optimization_stage1.jld2"
-    )
+    result = @optimize_or_load(outfile, problem; iter_stop=5, method=:dummymethod)
     @test result.converged
-    result1 = load_optimization(file)
+    result1 = load_optimization(outfile)
     result2 = optimize(problem; method=:dummymethod, iter_stop=15, continue_from=result1)
     @test result2.iter == 15
 end


### PR DESCRIPTION
DrWatson's philosophy of automatically naming output files in `DrWatson.@produce_or_load` did not do well with `@optimize_or_load`. Deducing some automatic filename from a given `problem` is cumbersome to say the least. In practice, I almost always want to pass an explicit filename.

Thus, `file` (the combination of the previous `path` and `filename`) must now be passed as the first positional argument to `@optimize_or_load`. The keyword arguments `filename`, `prefix`, `savename_kwargs`, that controlled the automatic file naming have been removed. The `dry_run` keyword argument has been removed, since it now has no effect.

The `@optimize_or_load` macro now returns only the optimization result, instead of a tuple consisting of the optimization result and the output file.

The `optimization_savename` and `default_optimization_savename_kwargs` routines have been removed.