### PR TITLE
Add `Amplitudes` and `PulseParametrizations`

### DIFF
--- a/src/QuantumControlBase.jl
+++ b/src/QuantumControlBase.jl
@@ -14,10 +14,12 @@ include("infohook.jl")
 export chain_infohooks
 
 
-include("shapes.jl")               # submodule Shapes
-include("functionals.jl")          # submodule Functionals
-include("weyl_chamber.jl")         # submodule WeylChamber
-include("testutils.jl")            # submodule TestUtils
+include("pulse_parametrizations.jl")  # submodule PulseParametrizations
+include("amplitudes.jl")              # submodule Amplitudes
+include("shapes.jl")                  # submodule Shapes
+include("functionals.jl")             # submodule Functionals
+include("weyl_chamber.jl")            # submodule WeylChamber
+include("testutils.jl")               # submodule TestUtils
 
 
 include("optimize.jl")

--- a/src/amplitudes.jl
+++ b/src/amplitudes.jl
@@ -1,0 +1,431 @@
+module Amplitudes
+
+export LockedAmplitude, ShapedAmplitude, ParametrizedAmplitude
+
+using QuantumPropagators.Generators: discretize_on_midpoints
+import QuantumPropagators.Generators:
+    getcontrols, substitute_controls, evalcontrols, getcontrolderiv
+using ..PulseParametrizations: PulseParametrization, SquareParametrization
+
+
+#### LockedAmplitude ##########################################################
+
+
+"""A time-dependent amplitude that is not a control.
+
+```julia
+ampl = LockedAmplitude(shape)
+```
+
+wraps around `shape`, which must be either a vector of values defined on the
+midpoints of a time grid or a callable `shape(t)`.
+
+```julia
+ampl = LockedAmplitude(shape, tlist)
+```
+
+discretizes `shape` to the midpoints of `tlist`.
+"""
+abstract type LockedAmplitude end
+
+
+function LockedAmplitude(shape)
+    if shape isa Vector{Float64}
+        return LockedPulseAmplitude(shape)
+    else
+        return LockedContinuousAmplitude(shape)
+    end
+end
+
+
+function LockedAmplitude(shape, tlist)
+    return LockedPulseAmplitude(discretize_on_midpoints(shape, tlist))
+end
+
+
+function Base.show(io::IO, ampl::LockedAmplitude)
+    print(io, "LockedAmplitude(::$(typeof(ampl.shape)))")
+end
+
+
+struct LockedPulseAmplitude <: LockedAmplitude
+    shape::Vector{Float64}
+end
+
+
+Base.Array(ampl::LockedPulseAmplitude) = ampl.shape
+
+
+struct LockedContinuousAmplitude <: LockedAmplitude
+
+    shape
+
+    function LockedContinuousAmplitude(shape)
+        try
+            S_t = shape(0.0)
+        catch
+            error("A LockedAmplitude shape must either be a vector of values or a callable")
+        end
+        return new(shape)
+    end
+
+end
+
+(ampl::LockedContinuousAmplitude)(t::Float64) = ampl.shape(t)
+
+getcontrols(ampl::LockedAmplitude) = ()
+
+substitute_controls(ampl::LockedAmplitude, controls_map) = ampl
+
+function evalcontrols(ampl::LockedPulseAmplitude, vals_dict, tlist, n)
+    return ampl.shape[n]
+end
+
+function evalcontrols(ampl::LockedContinuousAmplitude, vals_dict, tlist, n)
+    # It's technically possible to determine t from (tlist, n), but maybe we
+    # shouldn't
+    error("LockedAmplitude must be initialized with tlist")
+end
+
+getcontrolderiv(ampl::LockedAmplitude, control) =
+    (control ≡ ampl.control) ? LockedAmplitude(ampl.shape) : 0.0
+
+
+#### ControlAmplitude #########################################################
+
+
+# An amplitude that has `control` as the first field
+abstract type ControlAmplitude end
+
+getcontrols(ampl::ControlAmplitude) = (ampl.control,)
+
+function substitute_controls(ampl::CT, controls_map) where {CT<:ControlAmplitude}
+    control = get(controls_map, ampl.control, ampl.control)
+    CT(control, (getfield(ampl, field) for field in fieldnames(CT)[2:end])...)
+end
+
+
+#### ShapedAmplitude ##########################################################
+
+
+"""Product of a fixed shape and a control.
+
+```julia
+ampl = ShapedAmplitude(control; shape=shape)
+```
+
+produces an amplitude ``a(t) = S(t) ϵ(t)``, where ``S(t)`` corresponds to
+`shape` and ``ϵ(t)`` corresponds to `control`. Both `control` and `shape`
+should be either a vector of values defined on the midpoints of a time grid or
+a callable `control(t)`, respectively `shape(t)`. In the latter case, `ampl`
+will also be callable.
+
+```julia
+ampl = ShapedAmplitude(control, tlist; shape=shape)
+```
+
+discretizes `control` and `shape` to the midpoints of `tlist`.
+"""
+abstract type ShapedAmplitude <: ControlAmplitude end
+
+function ShapedAmplitude(control; shape)
+    if (control isa Vector{Float64}) && (shape isa Vector{Float64})
+        return ShapedPulseAmplitude(control, shape)
+    else
+        try
+            ϵ_t = control(0.0)
+        catch
+            error(
+                "A ShapedAmplitude control must either be a vector of values or a callable"
+            )
+        end
+        try
+            S_t = shape(0.0)
+        catch
+            error("A ShapedAmplitude shape must either be a vector of values or a callable")
+        end
+        return ShapedContinuousAmplitude(control, shape)
+    end
+end
+
+function Base.show(io::IO, ampl::ShapedAmplitude)
+    print(io, "ShapedAmplitude(::$(typeof(ampl.control)); shape::$(typeof(ampl.shape)))")
+end
+
+function ShapedAmplitude(control, tlist; shape)
+    control = discretize_on_midpoints(control, tlist)
+    shape = discretize_on_midpoints(shape, tlist)
+    return ShapedPulseAmplitude(control, shape)
+end
+
+struct ShapedPulseAmplitude <: ShapedAmplitude
+    control::Vector{Float64}
+    shape::Vector{Float64}
+end
+
+Base.Array(ampl::ShapedPulseAmplitude) = ampl.control .* ampl.shape
+
+
+struct ShapedContinuousAmplitude <: ShapedAmplitude
+    control
+    shape
+end
+
+(ampl::ShapedContinuousAmplitude)(t::Float64) = ampl.shape(t) * ampl.control(t)
+
+
+function evalcontrols(ampl::ShapedPulseAmplitude, vals_dict, tlist, n)
+    return ampl.shape[n] * vals_dict[ampl.control]
+end
+
+function evalcontrols(ampl::ShapedContinuousAmplitude, vals_dict, tlist, n)
+    # It's technically possible to determind t from (tlist, n), but maybe we
+    # shouldn't
+    error("ShapedAmplitude must be initialized with tlist")
+end
+
+getcontrolderiv(ampl::ShapedAmplitude, control) =
+    (control ≡ ampl.control) ? LockedAmplitude(ampl.shape) : 0.0
+
+
+#### ParametrizedAmplitude ####################################################
+
+
+"""An amplitude determined by a pulse parametrization.
+
+That is, ``a(t) = a(ϵ(t))`` with a bijective mapping between the value of
+``a(t)`` and ``ϵ(t)``, e.g. ``a(t) = ϵ^2(t)`` (a [`SquareParametrization`](@ref
+SquareParametrization)). Optionally, the amplitude may be multiplied with an
+additional shape function, cf. [`ShapedAmplitude`](@ref).
+
+
+```julia
+ampl = ParametrizedAmplitude(control; parametrization)
+```
+
+initilizes ``a(t) = a(ϵ(t)`` where ``ϵ(t)`` is the `control`, and the mandatory
+keyword argument `parametrization` is a [`PulseParametrization`](@ref
+PulseParametrization). The `control` must either be a vector of values
+discretized to the midpoints of a time grid, or a callable `control(t)`.
+
+```julia
+ampl = ParametrizedAmplitude(control; parametrization, shape=shape)
+```
+
+initializes ``a(t) = S(t) a(ϵ(t))`` where ``S(t)`` is the given `shape`. It
+must be a vector if `control` is a vector, or a callable `shape(t)` if
+`control` is a callable.
+
+
+```julia
+ampl = ParametrizedAmplitude(control, tlist; parametrization, shape=shape)
+```
+
+discretizes `control` and `shape` (if given) to the midpoints of `tlist` before
+initialization.
+
+
+```julia
+ampl = ParametrizedAmplitude(
+    amplitude, tlist; parametrization, shape=shape, parametrize=true
+)
+```
+
+initializes ``ã(t) = S(t) a(t)`` where ``a(t)`` is the input `amplitude`.
+First, if `amplitude` is a callable `amplitude(t)`, it is discretized to the
+midpoints of `tlist`. Then, a `control` ``ϵ(t)`` is calculated so that ``a(t) ≈
+a(ϵ(t))``. Clippling may occur if the values in `amplitude` cannot represented
+with the given `parametrization`. Lastly, `ParametrizedAmplitude(control;
+parametrization, shape)` is initialized with the calculated `control`.
+
+Note that the `tlist` keyword argument is required when `parametrize=true` is
+given, even if `amplitude` is already a vector.
+"""
+abstract type ParametrizedAmplitude <: ControlAmplitude end
+
+abstract type ShapedParametrizedAmplitude <: ParametrizedAmplitude end
+
+function ParametrizedAmplitude(
+    control;
+    parametrization::PulseParametrization,
+    shape=nothing
+)
+    if isnothing(shape)
+        if control isa Vector{Float64}
+            return ParametrizedPulseAmplitude(control, parametrization)
+        else
+            try
+                S_t = shape(0.0)
+            catch
+                error(
+                    "A ParametrizedAmplitude control must either be a vector of values or a callable"
+                )
+            end
+            return ParametrizedContinousAmplitude(control, parametrization)
+        end
+    else
+        if (control isa Vector{Float64}) && (shape isa Vector{Float64})
+            return ShapedParametrizedPulseAmplitude(control, shape)
+        else
+            try
+                ϵ_t = control(0.0)
+            catch
+                error(
+                    "A ParametrizedAmplitude control must either be a vector of values or a callable"
+                )
+            end
+            try
+                S_t = shape(0.0)
+            catch
+                error(
+                    "A ParametrizedAmplitude shape must either be a vector of values or a callable"
+                )
+            end
+            return ShapedParametrizedContinuousAmplitude(control, shape)
+        end
+    end
+end
+
+
+function ParametrizedAmplitude(
+    control,
+    tlist;
+    parametrization::PulseParametrization,
+    shape=nothing,
+    parameterize=false
+)
+    control = discretize_on_midpoints(control, tlist)
+    if parameterize
+        control = parametrization.epsilon_of_a.(control)
+    end
+    if !isnothing(shape)
+        shape = discretize_on_midpoints(shape, tlist)
+    end
+    return ParametrizedAmplitude(control; parametrization, shape)
+end
+
+function Base.show(io::IO, ampl::ParametrizedAmplitude)
+    print(
+        io,
+        "ParametrizedAmplitude(::$(typeof(ampl.control)); parametrization=$(ampl.parametrization))"
+    )
+end
+
+function Base.show(io::IO, ampl::ShapedParametrizedAmplitude)
+    print(
+        io,
+        "ParametrizedAmplitude(::$(typeof(ampl.control)); parametrization=$(ampl.parametrization), shape::$(typeof(ampl.shape)))"
+    )
+end
+
+struct ParametrizedPulseAmplitude <: ParametrizedAmplitude
+    control::Vector{Float64}
+    parametrization::PulseParametrization
+end
+
+function Base.Array(ampl::ParametrizedPulseAmplitude)
+    return ampl.parametrization.a_of_epsilon.(ampl.control)
+end
+
+struct ParametrizedContinuousAmplitude <: ParametrizedAmplitude
+    control
+    parametrization::PulseParametrization
+end
+
+struct ShapedParametrizedPulseAmplitude <: ShapedParametrizedAmplitude
+    control::Vector{Float64}
+    shape::Vector{Float64}
+    parametrization::PulseParametrization
+end
+
+struct ShapedParametrizedContinuousAmplitude <: ShapedParametrizedAmplitude
+    control
+    shape
+    parametrization::PulseParametrization
+end
+
+
+function evalcontrols(ampl::ParametrizedAmplitude, vals_dict, tlist, n)
+    return ampl.parametrization.a_of_epsilon(vals_dict[ampl.control])
+end
+
+function evalcontrols(ampl::ShapedParametrizedPulseAmplitude, vals_dict, tlist, n)
+    return ampl.shape[n] * ampl.parametrization.a_of_epsilon(vals_dict[ampl.control])
+end
+
+function Base.Array(ampl::ShapedParametrizedPulseAmplitude)
+    return ampl.shape .* ampl.parametrization.a_of_epsilon.(ampl.control)
+end
+
+function evalcontrols(ampl::ShapedParametrizedContinuousAmplitude, vals_dict, tlist, n)
+    # It's technically possible to determine t from (tlist, n), but maybe we
+    # shouldn't
+    error("ParametrizedAmplitude must be initialized with tlist")
+end
+
+
+function getcontrolderiv(ampl::ParametrizedAmplitude, control)
+    if control ≡ ampl.control
+        return ParametrizationDerivative(control, ampl.parametrization.da_deps_derivative)
+    else
+        return 0.0
+    end
+end
+
+function getcontrolderiv(ampl::ShapedParametrizedPulseAmplitude, control)
+    if control ≡ ampl.control
+        return ShapedParametrizationPulseDerivative(
+            control,
+            ampl.parametrization.da_deps_derivative,
+            ampl.shape
+        )
+    else
+        return 0.0
+    end
+end
+
+function getcontrolderiv(ampl::ShapedParametrizedContinuousAmplitude, control)
+    if control ≡ ampl.control
+        return ShapedParametrizationContinuousDerivative(
+            control,
+            ampl.parametrization.da_deps_derivative,
+            ampl.shape
+        )
+    else
+        return 0.0
+    end
+end
+
+struct ParametrizationDerivative <: ControlAmplitude
+    control
+    func
+end
+
+struct ShapedParametrizationPulseDerivative <: ControlAmplitude
+    control::Vector{Float64}
+    func
+    shape::Vector{Float64}
+end
+
+struct ShapedParametrizationContinuousDerivative <: ControlAmplitude
+    control
+    func
+    shape
+end
+
+function evalcontrols(deriv::ParametrizationDerivative, vals_dict, _...)
+    return deriv.func(vals_dict[deriv.control])
+end
+
+function evalcontrols(deriv::ShapedParametrizationPulseDerivative, vals_dict, tlist, n)
+    return deriv.shape[n] * deriv.func(vals_dict[deriv.control])
+end
+
+function evalcontrols(deriv::ShapedParametrizationContinuousDerivative, vals_dict, tlist, n)
+    # It's technically possible to determine t from (tlist, n), but maybe we
+    # shouldn't
+    error("ParametrizedAmplitude must be initialized with tlist")
+end
+
+
+end

--- a/src/pulse_parametrizations.jl
+++ b/src/pulse_parametrizations.jl
@@ -1,0 +1,156 @@
+module PulseParametrizations
+
+export SquareParametrization,
+    TanhParametrization,
+    TanhSqParametrization,
+    LogisticParametrization,
+    LogisticSqParametrization
+
+
+#! format: off
+
+
+"""Specification for a "time-local" pulse parametrization.
+
+The parametrization is given as a collection of three functions:
+
+* ``a(ϵ(t))``
+* ``ϵ(a(t))``
+* ``∂a/∂ϵ`` as a function of ``ϵ(t)``.
+"""
+struct PulseParametrization
+    name::String
+    a_of_epsilon::Function
+    epsilon_of_a::Function
+    da_deps_derivative::Function
+end
+
+
+function Base.show(io::IO, p::PulseParametrization)
+    print(io, p.name)
+end
+
+
+"""Parametrization a(t) = ϵ²(t), enforcing pulse values ``a(t) ≥ 0``."""
+SquareParametrization() = PulseParametrization(
+    "SquareParametrization()",
+    ϵ -> begin # a_of_epsilon
+        a = ϵ^2
+    end,
+    a -> begin # epsilon_of_a
+        a = max(a, 0.0)
+        ϵ = √a
+    end,
+    ϵ -> begin # da_deps_derivative
+        ∂a╱∂ϵ = 2ϵ
+    end
+)
+
+
+"""Parametrization with a tanh function that enforces `a_min < a(t) < a_max`.
+"""
+function TanhParametrization(a_min, a_max)
+
+    Δ = a_max - a_min
+    Σ = a_max + a_min
+    aₚ = eps(1.0)  # 2⋅10⁻¹⁶ (machine precision)
+    @assert a_max > a_min
+
+    PulseParametrization(
+        "TanhParametrization($a_min, $a_max)",
+        ϵ -> begin # a_of_epsilon
+            a = tanh(ϵ) * Δ / 2 + Σ / 2
+        end,
+        a -> begin # epsilon_of_a
+            a = clamp(2a / Δ - Σ / Δ, -1 + aₚ, 1 - aₚ)
+            ϵ = atanh(a)  # -18.4 < ϵ < 18.4
+        end,
+        ϵ -> begin # da_deps_derivative
+            ∂a╱∂ϵ = (Δ / 2) * sech(ϵ)^2
+        end
+    )
+
+end
+
+
+"""Parametrization with a tanh² function that enforces `0 ≤ a(t) < a_max`.
+"""
+function TanhSqParametrization(a_max)
+
+    aₚ = eps(1.0)  # 2⋅10⁻¹⁶ (machine precision)
+    @assert a_max > 0
+
+    PulseParametrization(
+        "TanhSqParametrization($a_max)",
+        ϵ -> begin # a_of_epsilon
+            a = a_max * tanh(ϵ)^2
+        end,
+        a -> begin # epsilon_of_a
+            a = clamp(a / a_max, 0, 1 - aₚ)
+            ϵ = atanh(√a)
+        end,
+        ϵ -> begin # da_deps_derivative
+            ∂a╱∂ϵ = 2a_max * tanh(ϵ) * sech(ϵ)^2
+        end
+    )
+
+end
+
+
+"""
+Parametrization with a Logistic function that enforces `a_min < a(t) < a_max`.
+"""
+function LogisticParametrization(a_min, a_max; k=1.0)
+
+    Δ = a_max - a_min
+    a₀ = eps(0.0)  # 5⋅10⁻³²⁴
+    @assert a_max > a_min
+
+    PulseParametrization(
+        "LogisticParametrization($a_max, $a_max; k=$k)",
+        ϵ -> begin # a_of_epsilon
+            a = Δ / (1 + exp(-k * ϵ)) + a_min
+        end,
+        a -> begin # epsilon_of_a
+            a′ = a - a_min
+            a = max(a′ / (Δ - a′), a₀)
+            ϵ = log(a) / k
+        end,
+        ϵ -> begin # da_deps_derivative
+            e⁻ᵏᵘ = exp(-k * ϵ)
+            ∂a╱∂ϵ = Δ * k * e⁻ᵏᵘ / (1 + e⁻ᵏᵘ)^2
+        end
+    )
+
+end
+
+
+"""
+Parametrization with a Logistic-Square function that enforces `0 ≤ a(t) < a_max`.
+"""
+function LogisticSqParametrization(a_max; k=1.0)
+
+    a₀ = eps(0.0)  # 5⋅10⁻³²⁴
+    @assert a_max > 0
+
+    PulseParametrization(
+        "LogisticSqParametrization($a_max; k=$k)",
+        ϵ -> begin # a_of_epsilon
+            a = a_max * (2 / (1 + exp(-k * ϵ)) - 1)^2
+        end,
+        a -> begin # epsilon_of_a
+            ρ = clamp(a / a_max, 0.0, 1.0)
+            a = clamp((2 / (√ρ + 1)) - 1, a₀, 1.0)
+            ϵ = -log(a) / k
+        end,
+        ϵ -> begin # da_deps_derivative
+            eᵏᵘ = exp(k * ϵ)
+            ∂a╱∂ϵ = 4k * a_max * eᵏᵘ * (eᵏᵘ - 1) / (eᵏᵘ + 1)^3
+        end
+    )
+
+end
+
+
+#! format: on
+end


### PR DESCRIPTION
This implements non-trivial control amplitudes such as `LockedAmplitude`, `ShapedAmplitude`, `ParametrizedAmplitude`. The latter allows for a more general implementation of pulse parametrization, e.g. `SquareParametrization`, `TanhParametrization`, `TanhSqParametrization`, `LogisticParametrization`, `LogisticSqParametrization`. These have been brought over from the Krotov package. However, the concept is now rephrased from `ϵ(u(t)` to `a(ϵ(t)`. Thus, the fields of `PulseParametrization` have changed names accordingly.