### PR TITLE
Refactor to add underscores to method names

### DIFF
--- a/src/derivs.jl
+++ b/src/derivs.jl
@@ -5,32 +5,32 @@ using QuantumPropagators.Amplitudes: LockedAmplitude, ShapedAmplitude
 """Get a vector of the derivatives of `generator` w.r.t. each control.
 
 ```julia
-getcontrolderivs(generator, controls)
+get_control_derivs(generator, controls)
 ```
 
 return as vector containing the derivative of `generator` with respect to each
 control in `controls`. The elements of the vector are either `nothing` if
 `generator` does not depend on that particular control, or a function `μ(α)`
 that evaluates the derivative for a particular value of the control, see
-[`getcontrolderiv`](@ref).
+[`get_control_deriv`](@ref).
 """
-function getcontrolderivs(generator, controls)
+function get_control_derivs(generator, controls)
     controlderivs = []
     for (i, control) in enumerate(controls)
-        push!(controlderivs, getcontrolderiv(generator, control))
+        push!(controlderivs, get_control_deriv(generator, control))
     end
     return [controlderivs...]  # narrow eltype
 end
 
-getcontrolderivs(operator::AbstractMatrix, controls) = [nothing for c ∈ controls]
-getcontrolderivs(operator::Operator, controls) = [nothing for c ∈ controls]
+get_control_derivs(operator::AbstractMatrix, controls) = [nothing for c ∈ controls]
+get_control_derivs(operator::Operator, controls) = [nothing for c ∈ controls]
 
 
 @doc raw"""
 Get the derivative of the generator ``G`` w.r.t. the control ``ϵ(t)``.
 
 ```julia
-μ  = getcontrolderiv(generator, control)
+μ  = get_control_deriv(generator, control)
 ```
 
 returns `nothing` if the `generator` (Hamiltonian or Liouvillian) does not
@@ -49,16 +49,16 @@ for particular values of the controls and a particular point in time.
 For constant generators, e.g. an [`Operator`](@ref), the result is always
 `nothing`.
 """
-function getcontrolderiv(generator::Tuple, control)
-    return getcontrolderiv(_make_generator(generator...), control)
+function get_control_deriv(generator::Tuple, control)
+    return get_control_deriv(_make_generator(generator...), control)
 end
 
 
-function getcontrolderiv(generator::Generator, control)
+function get_control_deriv(generator::Generator, control)
     terms = []
     drift_offset = length(generator.ops) - length(generator.amplitudes)
     for (i, ampl) in enumerate(generator.amplitudes)
-        ∂a╱∂ϵ = getcontrolderiv(ampl, control)
+        ∂a╱∂ϵ = get_control_deriv(ampl, control)
         if ∂a╱∂ϵ == 0.0
             continue
         elseif ∂a╱∂ϵ == 1.0
@@ -78,7 +78,7 @@ end
 
 @doc raw"""
 ```julia
-a = getcontrolderiv(ampl, control)
+a = get_control_deriv(ampl, control)
 ```
 
 returns the derivative ``∂a_l(t)/∂ϵ_{l'}(t)`` of the given amplitude
@@ -89,17 +89,17 @@ amplitudes, the result may be another amplitude that depends on the controls
 and potentially on time, but can be evaluated to a constant with
 [`evalcontrols`](@ref).
 """
-getcontrolderiv(ampl::Function, control) = (ampl ≡ control) ? 1.0 : 0.0
-getcontrolderiv(ampl::Vector, control) = (ampl ≡ control) ? 1.0 : 0.0
+get_control_deriv(ampl::Function, control) = (ampl ≡ control) ? 1.0 : 0.0
+get_control_deriv(ampl::Vector, control) = (ampl ≡ control) ? 1.0 : 0.0
 
-getcontrolderiv(operator::AbstractMatrix, control) = nothing
-getcontrolderiv(operator::Operator, control) = nothing
+get_control_deriv(operator::AbstractMatrix, control) = nothing
+get_control_deriv(operator::Operator, control) = nothing
 
 
 # Amplitudes
 
-getcontrolderiv(ampl::LockedAmplitude, control) =
+get_control_deriv(ampl::LockedAmplitude, control) =
     (control ≡ ampl.control) ? LockedAmplitude(ampl.shape) : 0.0
 
-getcontrolderiv(ampl::ShapedAmplitude, control) =
+get_control_deriv(ampl::ShapedAmplitude, control) =
     (control ≡ ampl.control) ? LockedAmplitude(ampl.shape) : 0.0

--- a/src/gradgen.jl
+++ b/src/gradgen.jl
@@ -2,7 +2,7 @@ import LinearAlgebra
 import QuantumPropagators
 import Base: -, *
 
-using QuantumPropagators.Generators: getcontrols, evalcontrols, evalcontrols!
+using QuantumPropagators.Generators: get_controls, evalcontrols, evalcontrols!
 
 
 @doc raw"""Extended generator for the standard dynamic gradient.
@@ -30,7 +30,7 @@ G̃ = \begin{pmatrix}
 
 Note that the ``∂G/∂ϵₗ(t)`` (``Ĥₗ`` in the above example) may be
 time-dependent, to account for the possibility of non-linear control terms, see
-[`getcontrolderiv`](@ref).
+[`get_control_deriv`](@ref).
 """
 struct GradGenerator{GT,CDT,CT}
     G::GT
@@ -38,8 +38,8 @@ struct GradGenerator{GT,CDT,CT}
     controls::Vector{CT}
 
     function GradGenerator(G::GT) where {GT}
-        controls = collect(getcontrols(G))
-        control_derivs = getcontrolderivs(G, controls)
+        controls = collect(get_controls(G))
+        control_derivs = get_control_derivs(G, controls)
         CT = eltype(controls)
         CDT = eltype(control_derivs)
         new{GT,CDT,CT}(G, control_derivs, controls)
@@ -82,14 +82,14 @@ function GradgenOperator(gradgen::GradGenerator)
 end
 
 
-function QuantumPropagators.Generators.getcontrols(gradgen::GradGenerator)
-    return getcontrols(gradgen.G)
+function QuantumPropagators.Generators.get_controls(gradgen::GradGenerator)
+    return get_controls(gradgen.G)
 end
 
 QuantumPropagators.Generators.evalcontrols(O::GradgenOperator, _...) = O
 QuantumPropagators.Generators.evalcontrols!(O1::T, O2::T, _...) where {T<:GradgenOperator} =
     O1
-QuantumPropagators.Generators.getcontrols(O1::GradgenOperator) = Tuple([])
+QuantumPropagators.Generators.get_controls(O1::GradgenOperator) = Tuple([])
 
 
 function QuantumPropagators.Generators.evalcontrols!(

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -4,7 +4,7 @@ using Printf
 
 using QuantumPropagators.Generators: Generator, Operator
 
-# TODO: consider using kwargs for initprop, and document that feature.
+# TODO: consider using kwargs for init_prop, and document that feature.
 """Optimization objective.
 
 ```julia
@@ -202,18 +202,18 @@ end
 
 """
 ```julia
-controls = getcontrols(objectives)
+controls = get_controls(objectives)
 ```
 
 extracts the controls from a list of objectives (i.e., from each objective's
 `generator`). Controls that occur multiple times in the different objectives
 will occur only once in the result.
 """
-function QuantumPropagators.Generators.getcontrols(objectives::Vector{<:Objective})
+function QuantumPropagators.Generators.get_controls(objectives::Vector{<:Objective})
     controls = []
     seen_control = IdDict{Any,Bool}()
     for obj in objectives
-        obj_controls = QuantumPropagators.Generators.getcontrols(obj.generator)
+        obj_controls = QuantumPropagators.Generators.get_controls(obj.generator)
         for control in obj_controls
             if !haskey(seen_control, control)
                 push!(controls, control)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -65,7 +65,7 @@ function optimize_or_load(
         "",
         Dict();
         filename=file,
-        suffix=suffix,
+        suffix="",
         tag=tag,
         gitpath=gitpath,
         loadfile=true,

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -38,8 +38,8 @@ propagate_objective(obj, tlist; method=:auto, initial_state=obj.initial_state,
 propagates `initial_state` under the dynamics described by `obj.generator`.
 
 The optional dict `control_map` may be given to replace the controls in
-`obj.generator` (as obtained by [`getcontrols`](@ref)) with custom functions or
-vectors, e.g. with the controls resulting from optimization, see also
+`obj.generator` (as obtained by [`get_controls`](@ref)) with custom functions
+or vectors, e.g. with the controls resulting from optimization, see also
 [`substitute_controls`](@ref).
 
 If `obj` has a property/field `prop_method` or `fw_prop_method`, its value will

--- a/src/pulse_parametrizations.jl
+++ b/src/pulse_parametrizations.jl
@@ -334,7 +334,7 @@ function evalcontrols(ampl::ShapedParametrizedContinuousAmplitude, vals_dict, tl
     error("ParametrizedAmplitude must be initialized with tlist")
 end
 
-function getcontrolderiv(ampl::ParametrizedAmplitude, control)
+function get_control_deriv(ampl::ParametrizedAmplitude, control)
     if control ≡ ampl.control
         return ParametrizationDerivative(control, ampl.parametrization.da_deps_derivative)
     else
@@ -342,7 +342,7 @@ function getcontrolderiv(ampl::ParametrizedAmplitude, control)
     end
 end
 
-function getcontrolderiv(ampl::ShapedParametrizedPulseAmplitude, control)
+function get_control_deriv(ampl::ShapedParametrizedPulseAmplitude, control)
     if control ≡ ampl.control
         return ShapedParametrizationPulseDerivative(
             control,
@@ -354,7 +354,7 @@ function getcontrolderiv(ampl::ShapedParametrizedPulseAmplitude, control)
     end
 end
 
-function getcontrolderiv(ampl::ShapedParametrizedContinuousAmplitude, control)
+function get_control_deriv(ampl::ShapedParametrizedContinuousAmplitude, control)
     if control ≡ ampl.control
         return ShapedParametrizationContinuousDerivative(
             control,

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -28,7 +28,7 @@ using LocalCoverage:
     FileCoverageSummary,
     CoverageTools
 using Printf
-using QuantumPropagators.Controls: getcontrols, discretize, discretize_on_midpoints
+using QuantumPropagators.Controls: get_controls, discretize, discretize_on_midpoints
 
 import ..Objective
 import ..ControlProblem
@@ -529,7 +529,7 @@ mutable struct DummyOptimizationResult
 
     function DummyOptimizationResult(problem)
         tlist = problem.tlist
-        controls = getcontrols(problem.objectives)
+        controls = get_controls(problem.objectives)
         iter_start = get(problem.kwargs, :iter_start, 0)
         iter = iter_start
         iter_stop = get(problem.kwargs, :iter_stop, 20)
@@ -569,7 +569,7 @@ end
 function DummyOptimizationWrk(problem)
     objectives = [obj for obj in problem.objectives]
     adjoint_objectives = [adjoint(obj) for obj in problem.objectives]
-    controls = getcontrols(objectives)
+    controls = get_controls(objectives)
     kwargs = Dict(problem.kwargs)
     tlist = problem.tlist
     if haskey(kwargs, :continue_from)

--- a/test/test_derivs.jl
+++ b/test/test_derivs.jl
@@ -1,6 +1,6 @@
 using Test
 using LinearAlgebra
-using QuantumControlBase: QuantumControlBase, getcontrolderiv, getcontrolderivs
+using QuantumControlBase: QuantumControlBase, get_control_deriv, get_control_derivs
 using QuantumPropagators
 using QuantumPropagators.Generators
 using QuantumPropagators.Controls
@@ -22,7 +22,7 @@ struct MyScaledAmpl
 end
 
 
-function QuantumControlBase.getcontrolderiv(a::MySquareAmpl, control)
+function QuantumControlBase.get_control_deriv(a::MySquareAmpl, control)
     if control ≡ a.control
         return MyScaledAmpl(2.0, control)
     else
@@ -36,7 +36,7 @@ function QuantumPropagators.Generators.evalcontrols(a::MyScaledAmpl, vals_dict, 
 end
 
 
-@testset "Standard getcontrolderivs" begin
+@testset "Standard get_control_derivs" begin
     H₀ = random_hermitian_matrix(5, 1.0)
     H₁ = random_hermitian_matrix(5, 1.0)
     H₂ = random_hermitian_matrix(5, 1.0)
@@ -44,13 +44,13 @@ end
     ϵ₂ = t -> 1.0
     H = (H₀, (H₁, ϵ₁), (H₂, ϵ₂))
 
-    @test getcontrolderiv(ϵ₁, ϵ₁) == 1.0
-    @test getcontrolderiv(ϵ₁, ϵ₂) == 0.0
+    @test get_control_deriv(ϵ₁, ϵ₁) == 1.0
+    @test get_control_deriv(ϵ₁, ϵ₂) == 0.0
 
-    derivs = getcontrolderivs(H₀, (ϵ₁, ϵ₂))
+    derivs = get_control_derivs(H₀, (ϵ₁, ϵ₂))
     @test all(isnothing.(derivs))
 
-    derivs = getcontrolderivs(H, (ϵ₁, ϵ₂))
+    derivs = get_control_derivs(H, (ϵ₁, ϵ₂))
     @test derivs[1] isa Matrix{ComplexF64}
     @test derivs[2] isa Matrix{ComplexF64}
     @test norm(derivs[1] - H₁) < 1e-14
@@ -61,12 +61,12 @@ end
         @test O ≡ deriv
     end
 
-    @test isnothing(getcontrolderiv(H, t -> 3.0))
+    @test isnothing(get_control_deriv(H, t -> 3.0))
 
 end
 
 
-@testset "Nonlinear getcontrolderivs" begin
+@testset "Nonlinear get_control_derivs" begin
 
     H₀ = random_hermitian_matrix(5, 1.0)
     H₁ = random_hermitian_matrix(5, 1.0)
@@ -75,7 +75,7 @@ end
     ϵ₂ = t -> 1.0
     H = (H₀, (H₁, MySquareAmpl(ϵ₁)), (H₂, MySquareAmpl(ϵ₂)))
 
-    derivs = getcontrolderivs(H, (ϵ₁, ϵ₂))
+    derivs = get_control_derivs(H, (ϵ₁, ϵ₂))
     @test derivs[1] isa Generator
     @test derivs[2] isa Generator
     @test derivs[1].ops[1] ≡ H₁
@@ -93,6 +93,6 @@ end
     @test O₂.ops[1] ≡ H₂
     @test O₂.coeffs[1] ≈ (2 * 2.0)
 
-    @test isnothing(getcontrolderiv(H, t -> 3.0))
+    @test isnothing(get_control_deriv(H, t -> 3.0))
 
 end

--- a/test/test_gradgen.jl
+++ b/test/test_gradgen.jl
@@ -1,6 +1,6 @@
 using Test
 using LinearAlgebra
-using QuantumPropagators: initprop, propstep!
+using QuantumPropagators: init_prop, prop_step!
 using QuantumPropagators.Newton
 using QuantumPropagators.SpectralRange: specrange
 using QuantumControlBase: GradGenerator, GradgenOperator, GradVector, resetgradvec!
@@ -118,7 +118,7 @@ using QuantumPropagators.Generators: evalcontrols
     ###########################################################################
     # Test standard expprop
 
-    propagator = initprop(
+    propagator = init_prop(
         Ψ̃,
         G̃,
         [0, dt];
@@ -127,7 +127,7 @@ using QuantumPropagators.Generators: evalcontrols
         convert_state=Vector{ComplexF64},
         convert_operator=Matrix{ComplexF64}
     )
-    Ψ̃_out_exp = propstep!(propagator)
+    Ψ̃_out_exp = prop_step!(propagator)
     @test norm(Ψ̃_out_exp - Ψ̃_out) < 1e-11
     resetgradvec!(Ψ̃, Ψ)
 

--- a/test/test_optimize_or_load.jl
+++ b/test/test_optimize_or_load.jl
@@ -15,6 +15,7 @@ using QuantumControlBase.TestUtils
         method=:dummymethod,
         metadata=Dict("testset" => "metadata", "method" => :dummymethod,)
     )
+    @show outfile
     @test result.converged
     @test isfile(outfile)
     result_load, metadata = load_optimization(outfile; return_metadata=true)


### PR DESCRIPTION
* `initprop` → `init_prop`
* `propstep!` → `prop_step!`
* `reinitprop!` → `reinit_prop!`
* `getcontrolderiv` → `get_control_deriv`
* `getcontrolderivs` → `get_control_derivs`
* `getcontrols` → `get_controls`

The old names were based on the [Julia Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base/) recommendation to name methods with "multiple words squashed together". I've come to regard this as a very bad idea. To quote the [JuMP style guide](https://jump.dev/JuMP.jl/stable/developers/style/), "This convention creates the potential for unnecessary bikeshedding and also forces the user to recall the presence/absence of an underscore, e.g., "was that argument named basename or base_name?". For consistency, always use underscores in variable names and function names to separate words.

See https://github.com/JuliaQuantumControl/QuantumPropagators.jl/pull/35