### PR TITLE
Protect against Zygote return types

### DIFF
--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -573,6 +573,7 @@ function make_automatic_chi(
             ∇J = Zygote.gradient(_J_T, ϕ...)
         end
         for (k, ∇Jₖ) ∈ enumerate(∇J)
+            ∇Jₖ = convert(typeof(χ[k]), ∇Jₖ)
             # |χₖ⟩ = ½ |∇Jₖ⟩  # ½ corrects for gradient vs Wirtinger deriv
             axpby!(0.5, ∇Jₖ, false, χ[k])
         end


### PR DESCRIPTION
Zygote sometimes returns things that aren't plain arrays, which then don't work with BLAS. Explicitly converting to arrays fixes that.