### PR TITLE
Fix methods for pulse parametrizations

### DIFF
--- a/src/pulse_parametrizations.jl
+++ b/src/pulse_parametrizations.jl
@@ -10,6 +10,9 @@ export SquareParametrization,
 using QuantumPropagators.Controls: discretize_on_midpoints
 using QuantumPropagators.Amplitudes: ControlAmplitude, ShapedAmplitude
 
+import QuantumPropagators.Controls: evaluate
+import ..get_control_deriv
+
 
 #! format: off
 


### PR DESCRIPTION
The `PulseParametrizations` sub-module was defining new methods for `evaluate` and `get_control_deriv` without importing them, thus making the definitions ineffective