### PR TITLE
Add `check_generator` routine

### DIFF
--- a/src/QuantumControlBase.jl
+++ b/src/QuantumControlBase.jl
@@ -11,6 +11,7 @@ include("propagate.jl")
 include("derivs.jl")
 include("functionals.jl")
 include("infohook.jl")
+include("check_generator.jl")
 include("optimize.jl")
 
 end

--- a/src/check_generator.jl
+++ b/src/check_generator.jl
@@ -1,0 +1,154 @@
+using QuantumPropagators
+using QuantumPropagators.Generators: Generator
+using QuantumPropagators.Controls: get_controls
+# from ./derivs.jl:  get_control_derivs, get_control_derivs
+
+
+"""Check the dynamical `generator` in the context of optimal control.
+
+```
+@test check_generator(generator; state, tlist,
+                     for_mutable_state=true, for_immutable_state=true,
+                     for_expval=true, for_gradient_optimization=true,
+                     atol=1e-15)
+```
+
+verifies the given `generator`. This checks all the conditions of
+[`QuantumPropagators.Interfaces.check_generator`](@ref). In addition, the
+following conditions must be met.
+
+If `for_gradient_optimization`:
+
+* `get_control_derivs(generator, controls)` must be defined and return a vector
+  containing the result of `get_control_deriv(generator, control)` for every
+  `control` in `controls`.
+* `get_control_deriv(generator, control)` must return an object that passes the
+  simpler [`QuantumPropagators.Interfaces.check_generator`](@ref) if `control`
+  is in `get_controls(generator)`.
+* `get_control_deriv(generator, control)` must return `nothing` if `control` is
+  not in `get_controls(generator)`
+* If `generator` is a [`Generator`](@ref) instance, for every `ampl` in
+  `generator.amplitudes`, a function `get_control_deriv(ampl, control)` must be
+  defined
+* If `ampl` does not depend on `control`, the function `get_control_deriv(ampl,
+  control)` must return `0.0`
+* Otherwise, `get_control_deriv(ampl, control)` must return an object `u` so
+  that `evaluate(u, tlist, n)` returns a Number. In most cases, `u` itself will
+  be a Number.
+"""
+function check_generator(
+    generator;
+    state,
+    tlist,
+    for_mutable_state=true,
+    for_immutable_state=true,
+    for_expval=true,
+    for_gradient_optimization=true,
+    atol=1e-15
+)
+
+    success = QuantumPropagators.Interfaces.check_generator(
+        generator;
+        state,
+        tlist,
+        for_mutable_state,
+        for_immutable_state,
+        for_expval,
+        atol
+    )
+
+    if for_gradient_optimization
+
+        try
+            controls = get_controls(generator)
+            control_derivs = get_control_derivs(generator, controls)
+            if !(control_derivs isa Vector)
+                @error "`get_control_derivs(generator, controls)` must return a Vector"
+                success = false
+            end
+            if length(control_derivs) ≠ length(controls)
+                @error "`get_control_derivs(generator, controls)` must return a derivative for every `control` in `controls`"
+                success = false
+            end
+            # In general, we can't check for equality between
+            # `get_control_deriv` and `get_control_deriv`, because `==` may not
+            # be implemented to compare arbitrary generators by value
+        catch exc
+            @error "`get_control_derivs(generator, controls)` must be defined: $exc"
+            success = false
+        end
+
+        try
+            controls = get_controls(generator)
+            for (i, control) in enumerate(controls)
+                deriv = get_control_deriv(generator, control)
+                valid_deriv = check_generator(
+                    deriv;
+                    state,
+                    tlist,
+                    for_mutable_state,
+                    for_immutable_state,
+                    for_expval,
+                    atol,
+                    for_gradient_optimization=false
+                )
+                if !valid_deriv
+                    @error "the result of `get_control_deriv(generator, control)` for control $i is not a valid generator"
+                    success = false
+                end
+            end
+        catch exc
+            @error "`get_control_deriv(generator, control)` must be defined: $exc"
+            success = false
+        end
+
+        try
+            controls = get_controls(generator)
+            dummy_control_CYRmE(t) = rand()
+            @assert dummy_control_CYRmE ∉ controls
+            deriv = get_control_deriv(generator, dummy_control_CYRmE)
+            if deriv ≢ nothing
+                @error "`get_control_deriv(generator, control)` must return `nothing` if `control` is not in `get_controls(generator)`, not $(repr(deriv))"
+                success = false
+            end
+        catch exc
+            @error "`get_control_deriv(generator, control)` must return `nothing` if `control` is not in `get_controls(generator)`: $exc"
+            success = false
+        end
+
+        if generator isa Generator
+            controls = get_controls(generator)
+            dummy_control_aSQeB(t) = rand()
+            @assert dummy_control_aSQeB ∉ controls
+            for (i, ampl) in enumerate(generator.amplitudes)
+                for (j, control) in enumerate(controls)
+                    try
+                        deriv = get_control_deriv(ampl, control)
+                        val = evaluate(deriv, tlist, 1)
+                        if !(val isa Number)
+                            @error "get_control_deriv(ampl, control) for amplitude $i and control $j must return an object that evaluate to a Number, not $(typeof(val))"
+                            success = false
+                        end
+                    catch exc
+                        @error "get_control_deriv(ampl, control) must be defined for amplitude $i and control $j"
+                        success = false
+                    end
+                end
+                try
+                    deriv = get_control_deriv(ampl, dummy_control_aSQeB)
+                    if deriv ≠ 0.0
+                        @error "get_control_deriv(ampl, control) for amplitude $i must return 0.0 if it does not depend on `control`, not $(repr(deriv))"
+                        success = false
+                    end
+                catch exc
+                    @error "get_control_deriv(ampl, control) must be defined for amplitude $i"
+                    success = false
+                end
+            end
+        end
+
+    end
+
+    return success
+
+end

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,5 +1,7 @@
 using QuantumPropagators.Controls: substitute
-using QuantumPropagators.Interfaces: check_state, check_generator
+using QuantumPropagators.Interfaces: check_state
+# from ./check_generator.jl: check_generator
+
 
 """Optimize a quantum control problem.
 
@@ -43,7 +45,6 @@ function optimize(
             if !check_state(obj.initial_state; for_immutable_state, for_mutable_state)
                 error("The `initial_state` of objective $i is not valid")
             end
-            # TODO: call the QuantumControl check_generator
             if !check_generator(
                 obj.generator;
                 state=obj.initial_state,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,11 @@ using SafeTestsets
         include("test_adjoint_objective.jl")
     end
 
+    print("\n* Invalid interfaces (test_invalid_interfaces.jl):")
+    @time @safetestset "Invalid interfaces" begin
+        include("test_invalid_interfaces.jl")
+    end
+
     print("\n")
 
 end;

--- a/test/test_invalid_interfaces.jl
+++ b/test/test_invalid_interfaces.jl
@@ -1,0 +1,77 @@
+using Test
+using Logging: with_logger
+using LinearAlgebra: I
+using QuantumPropagators
+using QuantumControlTestUtils: QuantumTestLogger
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
+using QuantumControlBase: check_generator
+
+
+import QuantumPropagators.Controls: get_controls, evaluate, evaluate!, substitute
+
+struct InvalidGenerator
+    control
+end
+
+# Define the methods required for propagation, but not the methods required
+# for gradients
+get_controls(G::InvalidGenerator) = (G.control,)
+evaluate(G::InvalidGenerator, args...) = I(4)
+evaluate!(op, G, args...) = op
+substitute(G::InvalidGenerator, args...) = G
+
+
+struct InvalidAmplitude
+    control
+end
+
+get_controls(a::InvalidAmplitude) = (a.control,)
+substitute(a::InvalidAmplitude, args...) = a
+evaluate(a::InvalidAmplitude, args...; kwargs...) = evaluate(a.control, args...; kwargs...)
+
+
+@testset "Invalid generator" begin
+
+    state = ComplexF64[1, 0, 0, 0]
+    tlist = collect(range(0, 10, length=101))
+
+    generator = InvalidGenerator(t -> 1.0)
+
+    @test QuantumPropagators.Interfaces.check_generator(generator; state, tlist)
+
+    test_logger = QuantumTestLogger()
+    with_logger(test_logger) do
+        @test check_generator(generator; state, tlist) ≡ false
+    end
+
+    @test "`get_control_derivs(generator, controls)` must be defined" ∈ test_logger
+    @test "`get_control_deriv(generator, control)` must return `nothing` if `control` is not in `get_controls(generator)`" ∈
+          test_logger
+
+end
+
+
+@testset "Invalid amplitudes" begin
+
+    N = 5
+    state = random_state_vector(N)
+    tlist = collect(range(0, 10, length=101))
+
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    ampl = InvalidAmplitude(t -> 1.0)
+
+    @test QuantumPropagators.Interfaces.check_amplitude(ampl; tlist)
+
+    H = hamiltonian(H₀, (H₁, ampl))
+
+    @test QuantumPropagators.Interfaces.check_generator(H; state, tlist)
+
+    test_logger = QuantumTestLogger()
+    with_logger(test_logger) do
+        @test check_generator(H; state, tlist) ≡ false
+    end
+
+    @test "get_control_deriv(ampl, control) must be defined" ∈ test_logger
+
+end


### PR DESCRIPTION
This extends `QuantumPropagators.Interfaces.check_generator` with the requirements for optimal control.

Moved from `QuantumControl.Interfaces`.