### PR TITLE
Add `check_amplitude` function

### DIFF
--- a/src/QuantumControlBase.jl
+++ b/src/QuantumControlBase.jl
@@ -11,6 +11,7 @@ include("propagate.jl")
 include("derivs.jl")
 include("functionals.jl")
 include("infohook.jl")
+include("check_amplitude.jl")
 include("check_generator.jl")
 include("optimize.jl")
 

--- a/src/check_amplitude.jl
+++ b/src/check_amplitude.jl
@@ -1,0 +1,67 @@
+using QuantumPropagators
+using QuantumPropagators.Controls: get_controls
+# from ./derivs.jl:  get_control_deriv
+
+
+"""
+Check an amplitude in a [`Generator`](@ref) in the context of optimal control.
+
+```
+@test check_amplitude(ampl; tlist, for_gradient_optimization=true)
+```
+
+verifies that the given `ampl` is a valid element in the list of `amplitudes`
+of a [`Generator`](@ref) object. This checks all the conditions of
+[`QuantumPropagators.Interfaces.check_amplitude`](@ref). In addition, the
+following conditions must be met.
+
+If `for_gradient_optimization`:
+
+* The function [`get_control_deriv(ampl, control)`](@ref get_control_deriv)
+  must be defined
+* If `ampl` does not depend on `control`, [`get_control_deriv(ampl,
+  control)`](@ref get_control_deriv) must return `0.0`
+* If `ampl` depends on `control`,
+  [`get_control_deriv(ampl, control)`](@ref get_control_deriv) must return an
+  object `u` so that `evaluate(u, tlist, n)` returns a Number. In most cases,
+  `u` itself will be a Number.
+"""
+function check_amplitude(ampl; tlist, for_gradient_optimization=true)
+
+    success = QuantumPropagators.Interfaces.check_amplitude(ampl; tlist)
+    success || (return false)
+
+    if for_gradient_optimization
+
+        controls = get_controls(ampl)  # guaranteed to work if success still true
+        dummy_control_aSQeB(t) = rand()
+        for (j, control) in enumerate(controls)
+            try
+                deriv = get_control_deriv(ampl, control)
+                val = evaluate(deriv, tlist, 1)
+                if !(val isa Number)
+                    @error "get_control_deriv(ampl, control) for  control $j must return an object that evaluates to a Number, not $(typeof(val))"
+                    success = false
+                end
+            catch exc
+                @error "get_control_deriv(ampl, control) must be defined for control $j: $exc"
+                success = false
+            end
+        end
+        @assert dummy_control_aSQeB ∉ controls
+        try
+            deriv = get_control_deriv(ampl, dummy_control_aSQeB)
+            if deriv ≠ 0.0
+                @error "get_control_deriv(ampl, control) must return 0.0 if it does not depend on `control`, not $(repr(deriv))"
+                success = false
+            end
+        catch exc
+            @error "get_control_deriv(ampl, control) must be defined: $exc"
+            success = false
+        end
+
+    end
+
+    return success
+
+end

--- a/src/derivs.jl
+++ b/src/derivs.jl
@@ -34,7 +34,7 @@ Get the derivative of the generator ``G`` w.r.t. the control ``ϵ(t)``.
 ```
 
 returns `nothing` if the `generator` (Hamiltonian or Liouvillian) does not
-depend on `control`, or generator
+depend on `control`, or a generator
 
 ```math
 μ = \frac{∂G}{∂ϵ(t)}

--- a/test/test_invalid_interfaces.jl
+++ b/test/test_invalid_interfaces.jl
@@ -4,9 +4,9 @@ using LinearAlgebra: I
 using QuantumPropagators
 using QuantumControlTestUtils: QuantumTestLogger
 using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
-using QuantumControlBase: check_generator
+using QuantumControlBase: check_generator, check_amplitude
 
-
+import QuantumControlBase: get_control_deriv
 import QuantumPropagators.Controls: get_controls, evaluate, evaluate!, substitute
 
 struct InvalidGenerator
@@ -28,6 +28,17 @@ end
 get_controls(a::InvalidAmplitude) = (a.control,)
 substitute(a::InvalidAmplitude, args...) = a
 evaluate(a::InvalidAmplitude, args...; kwargs...) = evaluate(a.control, args...; kwargs...)
+
+
+struct InvalidAmplitudeWrongDeriv
+    control
+end
+
+get_controls(a::InvalidAmplitudeWrongDeriv) = (a.control,)
+substitute(a::InvalidAmplitudeWrongDeriv, args...) = a
+evaluate(a::InvalidAmplitudeWrongDeriv, args...; kwargs...) =
+    evaluate(a.control, args...; kwargs...)
+get_control_deriv(::InvalidAmplitudeWrongDeriv, control) = nothing
 
 
 @testset "Invalid generator" begin
@@ -71,7 +82,16 @@ end
     with_logger(test_logger) do
         @test check_generator(H; state, tlist) ≡ false
     end
-
     @test "get_control_deriv(ampl, control) must be defined" ∈ test_logger
+
+    ampl = InvalidAmplitudeWrongDeriv(t -> 1.0)
+    test_logger = QuantumTestLogger()
+    with_logger(test_logger) do
+        check_amplitude(ampl; tlist)
+    end
+    @test "get_control_deriv(ampl, control) for  control 1 must return an object that evaluates to a Number" ∈
+          test_logger
+    @test "get_control_deriv(ampl, control) must return 0.0 if it does not depend on `control`" ∈
+          test_logger
 
 end


### PR DESCRIPTION
This supersedes `QuantumPropagators.Interfaces.check_amplitude` in the context of optimal control (just like `QuantumControlBase.check_generator` supersedes `QuantumPropagators.Interfaces.check_generator`)

It checks that amplitudes implement the required drivatives with respect to controls.