### PR TITLE
Allow Modules as propagation method, remove `:auto`

### DIFF
--- a/src/atexit.jl
+++ b/src/atexit.jl
@@ -8,7 +8,7 @@ A long-running optimization routine may use
 ```julia
 if !isnothing(atexit_filename)
     set_atexit_save_optimization(
-        atexit_filename, result; msg_property=:messsage, msg="Abort: ATEXIT"
+        atexit_filename, result; msg_property=:message, msg="Abort: ATEXIT"
     )
     # ...
     popfirst!(Base.atexit_hooks)  # remove callback
@@ -43,7 +43,7 @@ The resulting JLD2 file is compatible with `QuantumControl.load_optimization`.
 function set_atexit_save_optimization(
     filename,
     result;
-    msg_property=:messsage,
+    msg_property=:message,
     msg="Abort: ATEXIT"
 )
 

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -24,15 +24,24 @@ function get_objective_prop_method(obj, symbols...; kwargs...)
             return Symbol(getproperty(obj, symbol))
         end
     end
-    return :auto
+    throw(
+        ArgumentError(
+            "No propagation method from keywords $(repr(symbols)) of Objective with properties $(propertynames(obj)) or in optimization keyword arguments $(keys(kwargs))"
+        )
+    )
 end
 
 
 """Propagate with the dynamical generator of a control objective.
 
 ```julia
-propagate_objective(obj, tlist; method=:auto, initial_state=obj.initial_state,
-                    kwargs...)
+propagate_objective(
+    obj,
+    tlist;
+    method,  # mandatory keyword argument
+    initial_state=obj.initial_state,
+    kwargs...
+)
 ```
 
 propagates `initial_state` under the dynamics described by `obj.generator`.
@@ -44,25 +53,14 @@ argument for `method` always overrides the default.
 All other `kwargs` are forwarded to the underlying
 [`QuantumPropagators.propagate`](@ref) method for `obj.initial_state`.
 """
-function propagate_objective(
-    obj,
-    tlist;
-    method=:auto,
-    initial_state=obj.initial_state,
-    kwargs...
-)
-    if method == :auto
-        for symbol ∈ (:prop_method, :fw_prop_method)
-            if symbol ∈ propertynames(obj)
-                method = Symbol(getproperty(obj, symbol))
-            end
-        end
-    end
+function propagate_objective(obj, tlist; method, initial_state=obj.initial_state, kwargs...)
+    # TODO: get propagation method (and other options) from the properties of
+    # `obj`.
     return QuantumPropagators.propagate(
         initial_state,
         obj.generator,
-        tlist,
-        Val(method);
+        tlist;
+        method,
         kwargs...
     )
 end

--- a/test/test_optimize_kwargs.jl
+++ b/test/test_optimize_kwargs.jl
@@ -5,7 +5,7 @@ using QuantumControl: ControlProblem, Objective
 @testset "optimize-kwargs" begin
 
     # test that we can call optimize with kwargs that override the kwargs of
-    # the `problem` without permantly changing `problem`
+    # the `problem` without permanently changing `problem`
 
 
     struct Result

--- a/test/test_propagation.jl
+++ b/test/test_propagation.jl
@@ -1,5 +1,6 @@
 using Test
 using QuantumPropagators
+using QuantumPropagators: ExpProp
 using QuantumControlBase
 using QuantumPropagators.Shapes: flattop
 using UnicodePlots
@@ -39,7 +40,8 @@ using UnicodePlots
 
     tlist = collect(range(0, 5, length=500))
 
-    states = propagate(obj.initial_state, obj.generator, tlist, storage=true)
+    states =
+        propagate(obj.initial_state, obj.generator, tlist, storage=true, method=ExpProp)
 
     pops = abs.(states) .^ 2
     pop0 = pops[1, :]


### PR DESCRIPTION
The propagation `method` now must be explicitly specified, `:auto` is no longer an option.