### PR TITLE
Make `chi` functions not-in-place

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,12 +26,31 @@ links = InterLinks(
         joinpath(@__DIR__, "src", "inventories", "TimerOutputs.toml")
     ),
     "QuantumPropagators" => "https://juliaquantumcontrol.github.io/QuantumPropagators.jl/$DEV_OR_STABLE",
+    "QuantumControl" => "https://juliaquantumcontrol.github.io/QuantumControl.jl/$DEV_OR_STABLE",
+)
+
+externals = ExternalFallbacks(
+    "Generator" => "@extref QuantumPropagators :jl:type:`QuantumPropagators.Generators.Generator`",
+    "QuantumPropagators.Interfaces.check_amplitude" => "@extref QuantumPropagators :jl:function:`QuantumPropagators.Interfaces.check_amplitude`",
+    "evaluate" => "@extref QuantumPropagators :jl:function:`QuantumPropagators.Controls.evaluate`",
+    "Operator" => "@extref QuantumPropagators :jl:type:`QuantumPropagators.Generators.Operator`",
+    "QuantumPropagators.Interfaces.check_generator" => "@extref QuantumPropagators :jl:function:`QuantumPropagators.Interfaces.check_generator`",
+    "QuantumPropagators.AbstractPropagator" => "@extref QuantumPropagators :jl:type:`QuantumPropagators.AbstractPropagator`",
+    "QuantumPropagators.init_prop" => "@extref QuantumPropagators :jl:function:`QuantumPropagators.init_prop`",
+    "QuantumPropagators.propagate" => "@extref QuantumPropagators :jl:function:`QuantumPropagators.propagate`",
+    "QuantumControl.Functionals.J_T_sm" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.J_T_sm`",
+    # "QuantumControl.Functionals.chi_sm" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.chi_sm`",
+    "QuantumControl.Functionals.J_T_re" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.J_T_re`",
+    # "QuantumControl.Functionals.chi_re" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.chi_re`",
+    "QuantumControl.Functionals.J_T_ss" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.J_T_ss`",
+    # "QuantumControl.Functionals.chi_ss" => "@extref QuantumControl :jl:function:`QuantumControl.Functionals.chi_ss`",
+    "check_state" => "@extref QuantumPropagators :jl:function:`QuantumPropagators.Interfaces.check_state`"
 )
 
 println("Starting makedocs")
 
 makedocs(;
-    plugins=[bib, links],
+    plugins=[bib, links, externals],
     authors=AUTHORS,
     sitename="QuantumControlBase.jl",
     warnonly=false,

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -276,3 +276,25 @@
     Pages = {055012},
     Volume = {16},
 }
+
+@article{PalaoPRA2003,
+    Author = {Palao, José P. and Kosloff, Ronnie},
+    Title = {Optimal control theory for unitary transformations},
+    Journal = pra,
+    Year = {2003},
+    Doi = {10.1103/PhysRevA.68.062308},
+    Pages = {062308},
+    Volume = {68},
+}
+
+@article{GoerzQ2022,
+    Author = {Goerz, Michael H. and Carrasco, Sebastián C. and Malinovsky, Vladimir S.},
+    Title = {Quantum Optimal Control via Semi-Automatic Differentiation},
+    Journal = quant,
+    Year = {2022},
+    Doi = {10.22331/q-2022-12-07-871},
+    Pages = {871},
+    Volume = {6},
+}
+
+

--- a/ext/QuantumControlBaseFiniteDifferencesExt.jl
+++ b/ext/QuantumControlBaseFiniteDifferencesExt.jl
@@ -1,7 +1,6 @@
 module QuantumControlBaseFiniteDifferencesExt
 
 using QuantumControlBase: _default_chi_via
-using LinearAlgebra: axpby!
 import FiniteDifferences
 
 import QuantumControlBase: make_automatic_chi, make_automatic_grad_J_a
@@ -14,52 +13,57 @@ function make_automatic_chi(
     via=_default_chi_via(trajectories)
 )
 
-    function fdm_chi_via_phi!(χ, ϕ, trajectories; tau=nothing, τ=tau)
+    # TODO: Benchmark if χ should be closure, see QuantumControlBaseZygoteExt.jl
+
+    function fdm_chi_via_states(Ψ, trajectories)
         function _J_T(Ψ...)
             -J_T(Ψ, trajectories)
         end
         fdm = FiniteDifferences.central_fdm(5, 1)
-        ∇J = FiniteDifferences.grad(fdm, _J_T, ϕ...)
+        χ = Vector{eltype(Ψ)}(undef, length(Ψ))
+        ∇J = FiniteDifferences.grad(fdm, _J_T, Ψ...)
         for (k, ∇Jₖ) ∈ enumerate(∇J)
-            ∇Jₖ = convert(typeof(χ[k]), ∇Jₖ)
-            # |χₖ⟩ = ½ |∇Jₖ⟩  # ½ corrects for gradient vs Wirtinger deriv
-            axpby!(0.5, ∇Jₖ, false, χ[k])
+            χ[k] = 0.5 * ∇Jₖ  # ½ corrects for gradient vs Wirtinger deriv
+            # axpby!(0.5, ∇Jₖ, false, χ[k])
         end
+        return χ
     end
 
-    function fdm_chi_via_tau!(χ, ϕ, trajectories; tau=nothing, τ=tau)
+    function fdm_chi_via_tau(Ψ, trajectories; tau=nothing, τ=tau)
         if isnothing(τ)
-            msg = "chi! returned by `make_chi` with `via=:tau` requires keyword argument tau/τ"
+            msg = "`chi` returned by `make_chi` with `via=:tau` requires keyword argument tau/τ"
             throw(ArgumentError(msg))
         end
         function _J_T(τ...)
-            -J_T(ϕ, trajectories; τ=τ)
+            -J_T(Ψ, trajectories; tau=τ)
         end
         fdm = FiniteDifferences.central_fdm(5, 1)
+        χ = Vector{eltype(Ψ)}(undef, length(Ψ))
         ∇J = FiniteDifferences.grad(fdm, _J_T, τ...)
-        for (k, ∇Jₖ) ∈ enumerate(∇J)
-            ∂J╱∂τ̄ₖ = 0.5 * ∇Jₖ  # ½ corrects for gradient vs Wirtinger deriv
-            # |χₖ⟩ = (∂J/∂τ̄ₖ) |ϕₖ⟩
-            axpby!(∂J╱∂τ̄ₖ, trajectories[k].target_state, false, χ[k])
+        for (k, traj) ∈ enumerate(trajectories)
+            ∂J╱∂τ̄ₖ = 0.5 * ∇J[k]  # ½ corrects for gradient vs Wirtinger deriv
+            χ[k] = ∂J╱∂τ̄ₖ * traj.target_state
+            # axpby!(∂J╱∂τ̄ₖ, traj.target_state, false, χ[k])
         end
+        return χ
     end
 
-    if via ≡ :phi
-        return fdm_chi_via_phi!
+    if via ≡ :states
+        return fdm_chi_via_states
     elseif via ≡ :tau
-        ϕ_tgt = [traj.target_state for traj in trajectories]
-        if any(isnothing.(ϕ_tgt))
+        Ψ_tgt = [traj.target_state for traj in trajectories]
+        if any(isnothing.(Ψ_tgt))
             error("`via=:tau` requires that all trajectories define a `target_state`")
         end
-        τ_tgt = ComplexF64[1.0 for traj in trajectories]
-        if abs(J_T(ϕ_tgt, trajectories) - J_T(nothing, trajectories; τ=τ_tgt)) > 1e-12
-            error(
-                "`via=:tau` in `make_chi` requires that `J_T`=$(repr(J_T)) can be evaluated solely via `τ`"
-            )
+        τ_tgt = ones(ComplexF64, length(trajectories))
+        Ψ_undef = similar(Ψ_tgt)
+        if abs(J_T(Ψ_tgt, trajectories) - J_T(Ψ_undef, trajectories; tau=τ_tgt)) > 1e-12
+            msg = "`via=:tau` in `make_chi` requires that `J_T`=$(repr(J_T)) can be evaluated solely via `tau`"
+            error(msg)
         end
-        return fdm_chi_via_tau!
+        return fdm_chi_via_tau
     else
-        msg = "`via` must be either `:phi` or `:tau`, not $(repr(via))"
+        msg = "`via` must be either `:states` or `:tau`, not $(repr(via))"
         throw(ArgumentError(msg))
     end
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -8,7 +8,7 @@ print_iters = make_print_iters(Method; kwargs...)
 constructs the automatic callback to be used by
 `optimize(problem; method=Method, print_iters=true)` to print information after
 each iteration. The keyword arguments are those used to instantiate `problem`
-and those exlicitly passed to [`optimize`](@ref).
+and those explicitly passed to [`optimize`](@ref).
 
 Optimization methods should implement
 `make_print_iters(::Val{:Method}; kwargs...)` where `:Method` is the name

--- a/test/test_functionals.jl
+++ b/test/test_functionals.jl
@@ -40,30 +40,30 @@ PROBLEM = dummy_control_problem(;
     χ6 = [similar(traj.initial_state) for traj in trajectories]
     χ7 = [similar(traj.initial_state) for traj in trajectories]
     χ8 = [similar(traj.initial_state) for traj in trajectories]
-    ϕ = [random_state_vector(N_HILBERT; rng=RNG) for k = 1:N]
-    τ = [traj.target_state ⋅ ϕ[k] for (k, traj) in enumerate(trajectories)]
+    Ψ = [random_state_vector(N_HILBERT; rng=RNG) for k = 1:N]
+    τ = [traj.target_state ⋅ Ψ[k] for (k, traj) in enumerate(trajectories)]
 
     for functional in (J_T_sm, J_T_re, J_T_ss)
 
         #!format: off
-        chi_analytical! = make_chi(functional, trajectories; mode=:analytic)
-        chi_auto! = make_chi(functional, trajectories)
-        chi_zyg! = make_chi(functional, trajectories; mode=:automatic, automatic=Zygote)
-        chi_zyg_phi! = make_chi(functional, trajectories; mode=:automatic, automatic=Zygote, via=:phi)
-        chi_zyg_tau! = make_chi(functional, trajectories; mode=:automatic, automatic=Zygote, via=:tau)
-        chi_fdm! = make_chi(functional, trajectories; mode=:automatic, automatic=FiniteDifferences)
-        chi_fdm_phi! = make_chi(functional, trajectories; mode=:automatic, automatic=FiniteDifferences, via=:phi)
-        chi_fdm_tau! = make_chi(functional, trajectories; mode=:automatic, automatic=FiniteDifferences, via=:tau)
+        chi_analytical = make_chi(functional, trajectories; mode=:analytic)
+        chi_auto = make_chi(functional, trajectories)
+        chi_zyg = make_chi(functional, trajectories; mode=:automatic, automatic=Zygote)
+        chi_zyg_states = make_chi(functional, trajectories; mode=:automatic, automatic=Zygote, via=:states)
+        chi_zyg_tau = make_chi(functional, trajectories; mode=:automatic, automatic=Zygote, via=:tau)
+        chi_fdm = make_chi(functional, trajectories; mode=:automatic, automatic=FiniteDifferences)
+        chi_fdm_states = make_chi(functional, trajectories; mode=:automatic, automatic=FiniteDifferences, via=:states)
+        chi_fdm_tau = make_chi(functional, trajectories; mode=:automatic, automatic=FiniteDifferences, via=:tau)
         #!format: on
 
-        chi_analytical!(χ1, ϕ, trajectories; τ)
-        chi_auto!(χ2, ϕ, trajectories; τ)
-        chi_zyg!(χ3, ϕ, trajectories; τ)
-        chi_zyg_phi!(χ4, ϕ, trajectories; τ)
-        chi_zyg_tau!(χ5, ϕ, trajectories; τ)
-        chi_fdm!(χ6, ϕ, trajectories; τ)
-        chi_fdm_phi!(χ7, ϕ, trajectories; τ)
-        chi_fdm_tau!(χ8, ϕ, trajectories; τ)
+        χ1 = chi_analytical(Ψ, trajectories; τ)
+        χ2 = chi_auto(Ψ, trajectories; τ)
+        χ3 = chi_zyg(Ψ, trajectories; τ)
+        χ4 = chi_zyg_states(Ψ, trajectories)
+        χ5 = chi_zyg_tau(Ψ, trajectories; τ)
+        χ6 = chi_fdm(Ψ, trajectories; τ)
+        χ7 = chi_fdm_states(Ψ, trajectories)
+        χ8 = chi_fdm_tau(Ψ, trajectories; τ)
 
         @test maximum(norm.(χ1 .- χ2)) < 1e-12
         @test maximum(norm.(χ1 .- χ3)) < 1e-12


### PR DESCRIPTION
The `chi!` functions previously used by GRAPE and Krotov are now simply `chi` do not act in-place. This is more general and easier to implement for the user, as it allows to use immutable structs for states

Note that in extreme performance-critical situations, one could still construct the χ-states in-place via a closure or functor.

Both chi and J_T can now have an optional keyword argument `tau` (instead of the previous improperly implemented and unicode `τ`). Whether or not `tau` should be passed to these functions is automatically detected.